### PR TITLE
DektecInputPlugin:  fix bug and add feature; Zap plugin:  add feature

### DIFF
--- a/src/libtsduck/tsDektecInputPlugin.cpp
+++ b/src/libtsduck/tsDektecInputPlugin.cpp
@@ -153,7 +153,7 @@ bool ts::DektecInputPlugin::getOptions()
 {
     _guts->dev_index = intValue<int>(u"device", -1);
     _guts->chan_index = intValue<int>(u"channel", -1);
-    _guts->timeout_ms = intValue<int>(u"timeout", -1);
+    _guts->timeout_ms = intValue<int>(u"receive-timeout", -1);
     return true;
 }
 

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 986
+#define TS_COMMIT 988

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 988
+#define TS_COMMIT 989

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 989
+#define TS_COMMIT 990


### PR DESCRIPTION
This fixes a bug with the Dektec input plugin that prevented it from being used.  The timeout-related option is named "receive-timeout", yet it was expecting an option named "timeout".  Now, it expects an option named "receive-timeout".

Signed-off-by: Aaron Levinson <alevinsn_dev@levland.net>