### PR TITLE
Fixes ugly optimization

### DIFF
--- a/src/libtsduck/tsPacketEncapsulation.cpp
+++ b/src/libtsduck/tsPacketEncapsulation.cpp
@@ -169,6 +169,7 @@ bool ts::PacketEncapsulation::processPacket(TSPacket& pkt)
     PID pid = pkt.getPID();
     bool status = true;  // final return value.
 
+    if (_lateIndex < 1) _lateIndex = 1; // Resolves incorrect optimization in the initialization
     // Keep track of continuity counter per PID, detect discontinuity.
     // Do not check discontinuity on the stuffing PID, there is none.
     if (pid != PID_NULL) {


### PR DESCRIPTION
When packet processing starts, in this moment the value of _lateIndex is 0. And when the first packet is queued, this value changes to 1. However, some optmization breaks this, and only after the flush of the queue the value returns to 1.

So one simple solution to fix this trouble is to set it to 1 at starting time. In any case, when the loop empties the queue, the value is set to 1 (see last line of function fillPacket() ).

This resolves the ugly output of initial packets.