### PR TITLE
PES encapsulation implementation

### DIFF
--- a/src/libtsduck/tsPacketDecapsulation.cpp
+++ b/src/libtsduck/tsPacketDecapsulation.cpp
@@ -94,10 +94,114 @@ bool ts::PacketDecapsulation::processPacket(ts::TSPacket& pkt)
     // Where to look at in input packet. Start at beginning of payload.
     size_t pktIndex = pkt.getHeaderSize();
 
-    // Get pointer field in PUSI packets.
-    const bool pusi = pkt.getPUSI();
-    const size_t pointerField = pusi && pktIndex < PKT_SIZE ? pkt.b[pktIndex++] : 0;
-    if (pusi && pktIndex + pointerField > PKT_SIZE) {
+    // when PLAIN encapsulation is used corresponds to PUSI;
+    // and when using the PES encapsulation it's an internal flag.
+    bool start_mark = false;
+
+    // A special case may arise when one original PES packet is fragmented
+    // and the pointer to the next inernal packet points to a position in the
+    // second part of the packet. This offset solves the problem.
+    // However, it's good to overcome the fragmentation!
+    uint8_t pes_fragment = 0;
+
+    // Differentiate whether it's a plain encapsulation or a PES encapsulation
+    if (!pkt.getTEI() && pkt.isClear() && pkt.hasPayload()) { // General checks
+        if (pkt.getPUSI() && pktIndex < (PKT_SIZE - 9) &&
+            pkt.b[pktIndex]   == 0x00 &&
+            pkt.b[pktIndex+1] == 0x00 &&
+            pkt.b[pktIndex+2] == 0x01) {
+            // PES header found, continue...
+            pktIndex += 3;
+
+            // Check for correct Type Signature
+            if (pkt.b[pktIndex++] != 0xBD) {
+                return lostSync(pkt, u"invalid PES packet, type differs");
+            }
+            // Private Stream 1 found, continue...
+
+            // Check for PES Size and valid Flags
+            if (pkt.b[pktIndex++] != 0x00) {
+                return lostSync(pkt, u"invalid PES packet, size incompatible");
+            }
+            const size_t pes_size = pkt.b[pktIndex++];
+            // 178 bytes is the maximum PES packet size in origin.
+            // However, if an external processor splits the packet and inserts
+            // some PES header data (like PTS marks), then the size increases.
+            // We see PES lengths of 189, but a more conservative value is used.
+            if (pes_size > 255 || pes_size < 18) {
+                return lostSync(pkt, u"invalid PES packet, wrong size");
+            }
+            if (pkt.b[pktIndex] != 0x80 && pkt.b[pktIndex] != 0x84) {
+                return lostSync(pkt, u"invalid PES packet, incorrect flags");
+            }
+            pktIndex++; // Ignore these flags
+            pktIndex++; // Ignore these flags
+            size_t readed_size = pkt.b[pktIndex++]; // PES header size
+            if (readed_size > 0) {
+                // Advance up to the end of the PES header
+                pktIndex += readed_size;
+                pes_fragment = readed_size; // When fragmentation appears in the outer packet, this offset is added to checks.
+            }
+            // PES header OK!
+
+            // Start reading KLVA data...
+            if (pktIndex > PKT_SIZE - 18) {
+                return lostSync(pkt, u"invalid PES packet, data unknown");
+            }
+            // Check for our KLV correct KEY
+            // UL Used: 060E2B34.01010101.0F010800.0F0F0F0F
+            // This is an Unique ID in the testing range.
+            if (pkt.b[pktIndex]    != 0x06 && pkt.b[pktIndex+1]  != 0x0E && pkt.b[pktIndex+2]  != 0x2B && pkt.b[pktIndex+3]  != 0x34 &&
+                pkt.b[pktIndex+4]  != 0x01 && pkt.b[pktIndex+5]  != 0x01 && pkt.b[pktIndex+6]  != 0x01 && pkt.b[pktIndex+7]  != 0x01 &&
+                pkt.b[pktIndex+8]  != 0x0F && pkt.b[pktIndex+9]  != 0x01 && pkt.b[pktIndex+10] != 0x08 && pkt.b[pktIndex+11] != 0x00 &&
+                pkt.b[pktIndex+12] != 0x0F && pkt.b[pktIndex+13] != 0x0F && pkt.b[pktIndex+14] != 0x0F && (pkt.b[pktIndex+15] != 0x0F || pkt.b[pktIndex+15] != 0x1F)
+                ) {
+                return lostSync(pkt, u"invalid PES packet, incorrect UL Signature");
+            }
+            // KLV KEY OK, continue...
+            pktIndex += 16;
+            start_mark = pkt.b[pktIndex-1] & 0x10; // Get the equivalent PUSI flag from the last UL Key byte.
+
+            // Check for KLV correct LENGTH
+            readed_size = pkt.b[pktIndex++];
+            if (readed_size > 127 && readed_size != 0x81) {
+                return lostSync(pkt, u"invalid PES packet, incorrect KLVA size");
+            }
+            if (readed_size > 127) readed_size = pkt.b[pktIndex++]; // BER long mode
+            // KLV LENGTH OK, continue...
+
+            // Check for KLV correct VALUE
+            // No check here, this is the Data/Payload
+
+            // Warning: We assume that each packet is a complete PES packet.
+            // One special case is when an external processor has changed this,
+            // and here the PES packet is delivered in multiple TS packets!
+            // Following check breaks this case, so it's removed; as we can
+            // continue after this point with PUSI flag off like with plain
+            // encapsulation.
+            //#if (readed_size + pktIndex != PKT_SIZE) {
+            //#    return lostSync(pkt, u"invalid PES packet, KLVA payload doesn't match");
+            //#}
+            if (readed_size > 188) {
+                return lostSync(pkt, u"invalid PES packet, KLVA payload doesn't match");
+            }
+
+            // At this point ALL checks are OK!
+            // We assume this is a valid PES envelope.
+            }
+        else {
+            // We assume it's a PLAIN encapsultation.
+            start_mark = pkt.getPUSI();
+        }
+    } else return lostSync(pkt, u"incorrect packet");
+
+    // From this point the PES envelope is consumed (therefore transparent).
+    // We continue with the the PLAIN encapsulation.
+
+    // Get pointer field when INIT MARK appears.
+    const size_t pointerField = start_mark && pktIndex < PKT_SIZE ? pkt.b[pktIndex++] : 0;
+    if (start_mark && pktIndex + pointerField > PKT_SIZE + pes_fragment) {
+    // "pes_fragment" offset solves pointer overflows in fragmented outer packets.
         return lostSync(pkt, u"invalid packet, adaptation field or pointer field out of range");
     }
 
@@ -111,7 +215,7 @@ bool ts::PacketDecapsulation::processPacket(ts::TSPacket& pkt)
 
     // If we previously lost synchronization, try to resync in current packet.
     if (!_synchronized) {
-        if (pusi) {
+        if (start_mark) { // PUSI mark
             // There is a packet start here, we have a chance to resync.
             pktIndex += pointerField;
             _synchronized = true;

--- a/src/libtsduck/tsPacketEncapsulation.cpp
+++ b/src/libtsduck/tsPacketEncapsulation.cpp
@@ -42,6 +42,7 @@ const size_t ts::PacketEncapsulation::DEFAULT_MAX_BUFFERED_PACKETS;
 
 ts::PacketEncapsulation::PacketEncapsulation(PID pidOutput, const PIDSet& pidInput, PID pcrReference) :
     _packing(false),
+    _pesmode(0),
     _pidOutput(pidOutput),
     _pidInput(pidInput),
     _pcrReference(pcrReference),
@@ -67,6 +68,7 @@ ts::PacketEncapsulation::PacketEncapsulation(PID pidOutput, const PIDSet& pidInp
 void ts::PacketEncapsulation::reset(PID pidOutput, const PIDSet& pidInput, PID pcrReference)
 {
     _packing = false;
+    _pesmode = 0;
     _pidOutput = pidOutput;
     _pidInput = pidInput;
     _pcrReference = pcrReference;
@@ -211,6 +213,10 @@ bool ts::PacketEncapsulation::processPacket(TSPacket& pkt)
         status = false;
     }
 
+    // We need to guarantee the limits of all packages.
+    // When the buffer is empty we alredy set the late pointer to the first byte after 0x47.
+    if (_lateIndex < 1) _lateIndex = 1;
+
     // If this packet is part of the input set, place it in the "late" queue.
     // Note that a packet always need to go into the queue, even if the queue
     // is empty because no input packet can fit into an output packet. At least
@@ -232,6 +238,12 @@ bool ts::PacketEncapsulation::processPacket(TSPacket& pkt)
         pid = PID_NULL;
     }
 
+    // Check PES mode support
+    if (_pesmode > 2) {
+        _lastError.assign(u"PES mode %u not implemented!", _pesmode);
+        status = false;
+    }
+
     // Replace input or null packets.
     if (pid == PID_NULL && !_latePackets.empty()) {
 
@@ -241,12 +253,20 @@ bool ts::PacketEncapsulation::processPacket(TSPacket& pkt)
         // How many bytes do we have in the queue (at least).
         const size_t addBytes = (PKT_SIZE - _lateIndex) + (_latePackets.size() > 1 ? PKT_SIZE : 0);
 
+        // How many bytes consumes de PES encapsulation, based on this calculus:
+        //   26|27 bytes =
+        //               9 bytes PES header;
+        //            + 16 bytes KLVA UL key;
+        //            + 1 byte with BER short mode | 2 bytes with BER long mode.
+        const uint8_t pes_header = _pesmode > 0 ? (addBytes <= 127 || _pesmode == 1 ? 26 : 27) : 0;
+
         // Depending on packing option, we may decide to not insert an outer packet which is not full.
         // Available size in outer packet:
         //   PKT_SIZE
         //   -4 => TS header.
         //   -8 => Adaptation field in case of PCR: 1-byte AF size, 1-byte flags, 6-byte PCR.
         //   -1 => Pointer field, first byte of payload (not always, but very often).
+        // -26|27 => PES size (when PES mode is enabled)
         // We insert a packet all the time if packing is off.
         // Otherwise, we insert a packet when there is enough data to fill it.
         if (!_packing || addBytes >= PKT_SIZE - (addPCR ? 12 : 4) - 1) {
@@ -259,6 +279,10 @@ bool ts::PacketEncapsulation::processPacket(TSPacket& pkt)
             pkt.setPID(_pidOutput);
             pkt.setCC(_ccOutput);
             ::memset(pkt.b + 4, 0xFF, PKT_SIZE - 4);
+            pkt.b[4] = 0; // We temporally set Adaptation Field Length to 0
+                          // This position will be later overwritten:
+                          // or with data, or with a real Length value.
+                          // But setting it to zero simplifies the code.
 
             // Index in pkt where we write data. Start at beginning of payload.
             size_t pktIndex = 4;
@@ -287,32 +311,124 @@ bool ts::PacketEncapsulation::processPacket(TSPacket& pkt)
                 _insertPCR = false;
             }
 
+            // Calculate PES maximum envelope size
+            // (0 when disabled)
+            const uint8_t pes_maxsize = _pesmode > 0 ? (_pesmode == 1 ? 127 : (PKT_SIZE - (uint8_t(pkt.b[4]) + 4) - pes_header)) : 0;
+            // The upper limit of 127 is an artificial value; and it's not
+            // related with the payload max size of 127 bytes of the KLV packet.
+            // The aim is to provide enough free adaptation space in the header.
+
+            // Calculate PES minimum padding stuff required in the Adaptation field
+            // (0 when disabled) (equals to 0 when it's not needed)
+            const uint8_t pes_stuff   = _pesmode > 0 ? ((PKT_SIZE - (uint8_t(pkt.b[4]) + 4) - pes_header) - pes_maxsize) : 0;
+
             // If there are less "late" bytes than the output payload size, enlarge the adaptation field
             // with stuffing. Note that if there is so few bytes in the only "late" packet, this cannot
             // be the beginning of a packet and there will be no pointer field.
-            if (_latePackets.size() == 1 && _lateIndex > pktIndex) {
+            if (_latePackets.size() == 1 && _lateIndex > pktIndex + pes_header + pes_stuff) {
                 // This code works identically whether there was an adaptation field or not.
                 pkt.b[3] |= 0x20;  // adaptation field present
-                pkt.b[4] = uint8_t(_lateIndex - 5);  // adaptation field size
+                pkt.b[4] = uint8_t(_lateIndex - 5 - pes_header);  // adaptation field size
                 if (!addPCR) {
                     pkt.b[5] = 0x00; // AF flags
                 }
-                pktIndex = _lateIndex;
+                pktIndex = _lateIndex - pes_header;
+            }
+            else if (pes_stuff > 0) { // Add the alone padding only for PES.
+                pkt.b[3] |= 0x20;
+                pkt.b[4] = uint8_t(uint8_t(pkt.b[4]) + pes_stuff - 1);
+                if (!addPCR) {
+                    pkt.b[5] = 0x00;
+                }
+                pktIndex += pes_stuff;
             }
 
             // At this point, pktIndex points at the beginning of the TS payload.
             assert(pktIndex == pkt.getHeaderSize());
 
+            // When PES mode is ON add here the envelope before the data/payload
+            uint8_t pes_pointer = 0; // Indirect reference for futher completion
+            if (pes_header > 0) {
+
+                // Fill the PES Header
+
+                pkt.b[pktIndex++] = 0x00; // PES start code prefix
+                pkt.b[pktIndex++] = 0x00;
+                pkt.b[pktIndex++] = 0x01;
+
+                pkt.b[pktIndex++] = 0xBD; // Stream_id == Pivate_Stream_1
+
+                pkt.b[pktIndex++] = 0x00; // PES packet length (2 bytes)
+                pkt.b[pktIndex++] = 0x00; // Pending to complete at end (**)
+
+                pes_pointer = pktIndex;   // Store for reference
+
+                pkt.b[pktIndex++] = 0x84; // Header flags
+                pkt.b[pktIndex++] = 0x00; // Header flags
+                pkt.b[pktIndex++] = 0x00; // Length of remaining optional fields
+
+                // Fill the KLVA Data
+
+                // >>> (K)ey
+                // UL Used: 060E2B34.01010101.0F010800.0F0F0F0F
+                // It's an Unique ID value in the testing range.
+                pkt.b[pktIndex++] = 0x06;
+                pkt.b[pktIndex++] = 0x0e;
+                pkt.b[pktIndex++] = 0x2b;
+                pkt.b[pktIndex++] = 0x34;
+
+                pkt.b[pktIndex++] = 0x01;
+                pkt.b[pktIndex++] = 0x01;
+                pkt.b[pktIndex++] = 0x01;
+                pkt.b[pktIndex++] = 0x01;
+
+                pkt.b[pktIndex++] = 0x0f;
+                pkt.b[pktIndex++] = 0x01;
+                pkt.b[pktIndex++] = 0x08;
+                pkt.b[pktIndex++] = 0x00;
+
+                pkt.b[pktIndex++] = 0x0f;
+                pkt.b[pktIndex++] = 0x0f;
+                pkt.b[pktIndex++] = 0x0f;
+                pkt.b[pktIndex++] = 0x0f; // 0x1f when equivalent PUSI flag is set
+
+                // >>> (L)ength
+                uint8_t payload_size = PKT_SIZE - pktIndex - 1;
+                assert(payload_size > 0);
+                if (payload_size > 127) {
+                    pkt.b[pktIndex++] = 0x81; // Long flag with size length = 1
+                    payload_size--;
+                }
+                pkt.b[pktIndex++] = payload_size; // Final size of data/payload
+
+                // Update the remaining value of the PES packet length (**)
+                pkt.b[pes_pointer-1] = uint8_t(PKT_SIZE - pes_pointer);
+
+                // >>> (V)alue
+                // At this point the PES packet is fully filled and only remains the payload
+                assert(pktIndex < PKT_SIZE);
+
+                pkt.setPUSI(); // In PES mode any packet is an unique PES mode, so set the Payload Unit Start
+                // The PES encapsulation maps the PUSI flag at bit 0x10 in the last byte of the UL Key.
+            }
+
             // Insert PUSI and pointer field when necessary.
             if (_lateIndex == 1) {
                 // We immediately start with the start of a packet.
-                pkt.setPUSI();
+                // Note: The flag is different in the PES mode!
+                if (_pesmode > 0)
+                    pkt.b[pes_pointer+18] |= 0x10;
+                else
+                    pkt.setPUSI();
                 pkt.b[pktIndex++] = 0; // pointer field
             }
             else if (_lateIndex > pktIndex + 1 && _latePackets.size() > 1) {
                 // The remaining bytes in the first packet are less than the output payload,
                 // we will start a new packet in this payload.
-                pkt.setPUSI();
+                if (_pesmode > 0)
+                    pkt.b[pes_pointer+18] |= 0x10;
+                else
+                    pkt.setPUSI();
                 pkt.b[pktIndex++] = uint8_t(PKT_SIZE - _lateIndex); // pointer field
             }
 

--- a/src/libtsduck/tsPacketEncapsulation.h
+++ b/src/libtsduck/tsPacketEncapsulation.h
@@ -47,8 +47,8 @@ namespace ts {
     //! this is a subset of the features of T2-MI but much more lightweight
     //! and significantly faster to process.
     //!
-    //! Encapsulation format
-    //! --------------------
+    //! Encapsulation format (plain)
+    //! ----------------------------
     //! In the output elementary stream (ES), all input TS packets are
     //! contiguous, without encapsulation. The initial 0x47 synchronization
     //! byte is removed. Only the remaining 187 bytes are encapsulated.
@@ -64,6 +64,58 @@ namespace ts {
     //! is slightly larger than the input packets. The input streams must
     //! contain a few null packets to absorb the extra output packets. For
     //! this reason, null packets (PID 0x1FFF) are never encapsulated.
+    //!
+    //! Encapsulation format (PES)
+    //! --------------------------
+    //! When selecting the PES encapsulation the same plain elementary
+    //! stream is used, but with a PES envelope. This reduces the payload
+    //! size, but makes the outer encapsulation more transparent. The full
+    //! overhead is around 14% of more data.
+    //!
+    //! The PES envelope uses a KLVA SMPTE-336M encapsulation to insert the
+    //! inner payload into one private (testing) key. Each TS packet contains
+    //! only one key, with a size no larger than the payload of one TS packet.
+    //! So each PES packet fits into a single TS packet.
+    //!
+    //! The SMPTE-336M encapsulation is the asynchrouns one. So no PTS
+    //! marks are used, and the payload size is larger.
+    //!
+    //! Two variant strategies are implemented. The FIXED mode uses the
+    //! short (7bit) BER encoding. This limits the PES payload to a maximum
+    //! of 127 bytes. And the adaptation field of the outer packet is
+    //! enlarged with some stuff. However, the advantage is that the PES
+    //! is sufficient small to include more data in the outer TS packet.
+    //! This reduces the possibility than some external processing will
+    //! split the outer packet in two to accomodate the entire PES data.
+    //!
+    //! The VARIABLE mode does not imposses this restriction, and outer
+    //! packets are filled as maximum. The drawback is that some times
+    //! the long form of BER encoding is used with two bytes and others
+    //! the short form with one byte. Futhermore, this increases the chances
+    //! that some external procesing ocuppies two outer packets for the
+    //! same inner PES packet. Still, support for those split PES packets
+    //! is included. The only requirement is that the 26|27 PES+KLVA header
+    //! is inserted in the first packet (with PUSI on). The remaining
+    //! payload can be distributed in thge following TS packets.
+    //!
+    //! The PES envelope has an overhead of 26 or 27 bytes based on:
+    //!   9 bytes for the PES header.
+    //!  16 bytes for the UL key
+    //! 1|2 bytes for the payload size (BER short or long format)
+    //!
+    //! In order to correctly identify the encapsulated PES stream is
+    //! recommended to include in the PMT table a format identifier
+    //! descriptor for "KLVA" (0x4B4C5641); and use the Private Type (0x06)
+    //! for the stream type.
+    //!  Example:
+    //!   "tsp ... \                                                     "
+    //!   " -P encap -o 7777 --pes-mode ... \                            "
+    //!   " -P pmt -s 100 -a 7777/0x06 --add-programinfo-id 0x4B4C5641 \ "
+    //!   " ...                                                          "
+    //!   where the target pid is 7777 and the attached service is 100.
+    //!
+    //! References:
+    //! https://impleotv.com/2017/02/17/klv-encoded-metadata-in-stanag-4609-streams/
     //!
     class TSDUCKDLL PacketEncapsulation
     {
@@ -191,12 +243,22 @@ namespace ts {
         //!
         void setPacking(bool on) { _packing = on; }
 
+        //!
+        //! Set PES mode.
+        //! Enbles the PES mode encapsulation (disabled by default).
+        //! Accepted values are:
+        //! 0=disabled; 1=fixed; 2=variable.
+        //! @param [in] on PES mode.
+        //!
+        void setPES(uint8_t mode) { _pesmode = mode; }
+
     private:
         typedef std::map<PID,uint8_t> PIDCCMap;  // map of continuity counters, indexed by PID
         typedef SafePtr<TSPacket> TSPacketPtr;
         typedef std::deque<TSPacketPtr> TSPacketPtrQueue;
 
         bool             _packing;         // Packing mode.
+        uint8_t          _pesmode;         // PES mode selected.
         PID              _pidOutput;       // Output PID.
         PIDSet           _pidInput;        // Input PID's to encapsulate.
         PID              _pcrReference;    // Insert PCR's based on this reference PID.

--- a/src/libtsduck/tsPacketEncapsulation.h
+++ b/src/libtsduck/tsPacketEncapsulation.h
@@ -241,7 +241,7 @@ namespace ts {
         //! are emitted only when they are full.
         //! @param [in] on Packing mode.
         //!
-        void setPacking(bool on) { _packing = on; }
+        void setPacking(bool on, size_t limit) { _packing = on; _packDistance = limit; }
 
         //!
         //! Set PES mode.
@@ -258,6 +258,7 @@ namespace ts {
         typedef std::deque<TSPacketPtr> TSPacketPtrQueue;
 
         bool             _packing;         // Packing mode.
+        size_t           _packDistance;    // Maximum distance between inner packets.
         uint8_t          _pesmode;         // PES mode selected.
         PID              _pidOutput;       // Output PID.
         PIDSet           _pidInput;        // Input PID's to encapsulate.
@@ -270,6 +271,7 @@ namespace ts {
         bool             _insertPCR;       // Insert a PCR in next output packet.
         uint8_t          _ccOutput;        // Continuity counter in output PID.
         PIDCCMap         _lastCC;          // Continuity counter by PID.
+        size_t           _lateDistance;    // Distance from the last packet.
         size_t           _lateMaxPackets;  // Maximum number of packets in _latePackets.
         size_t           _lateIndex;       // Index in first late packet.
         TSPacketPtrQueue _latePackets;     // Packets to insert later.

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1048
+#define TS_COMMIT 1049

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1049
+#define TS_COMMIT 1048

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1049
+#define TS_COMMIT 1050

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1050
+#define TS_COMMIT 1049

--- a/src/tsplugins/tsplugin_encap.cpp
+++ b/src/tsplugins/tsplugin_encap.cpp
@@ -60,6 +60,7 @@ namespace ts {
         PID                 _pidOutput;     // Output PID.
         PID                 _pidPCR;        // PCR reference PID.
         PIDSet              _pidsInput;     // Input PID's.
+        uint8_t             _modePES;       // Enable PES mode and select type.
         PacketEncapsulation _encap;         // Encapsulation engine.
 
         // Inaccessible operations
@@ -85,6 +86,7 @@ ts::EncapPlugin::EncapPlugin(TSP* tsp_) :
     _pidOutput(PID_NULL),
     _pidPCR(PID_NULL),
     _pidsInput(),
+    _modePES(0),
     _encap()
 {
     option(u"ignore-errors", 'i');
@@ -124,6 +126,12 @@ ts::EncapPlugin::EncapPlugin(TSP* tsp_) :
          u"Specify an input PID or range of PID's to encapsulate. "
          u"Several --pid options can be specified. "
          u"The null PID 0x1FFF cannot be encapsulated.");
+
+    option(u"pes-mode", 0, INTEGER, 0, 1, 0, 2);
+    help(u"pes-mode", u"mode",
+         u"Enable PES mode encapsulation. "
+         u"Modes available are: "
+         u"0=disabled; 1=fixed; 2=variable.");
 }
 
 
@@ -138,6 +146,7 @@ bool ts::EncapPlugin::getOptions()
     _maxBuffered = intValue<size_t>(u"max-buffered-packets", PacketEncapsulation::DEFAULT_MAX_BUFFERED_PACKETS);
     _pidOutput = intValue<PID>(u"output-pid", PID_NULL);
     _pidPCR = intValue<PID>(u"pcr-pid", PID_NULL);
+    _modePES = intValue<uint8_t>(u"pes-mode", 0);
     getIntValues(_pidsInput, u"pid");
 
     return true;
@@ -152,6 +161,7 @@ bool ts::EncapPlugin::start()
 {
     _encap.reset(_pidOutput, _pidsInput, _pidPCR);
     _encap.setPacking(_pack);
+    _encap.setPES(_modePES);
     _encap.setMaxBufferedPackets(_maxBuffered);
     return true;
 }


### PR DESCRIPTION
Hi,

I present here a _second_ alternative format for the encapsulation (`encap` and `decap` filters).

You can found a deep description in the comment included in the header. See it here:
https://github.com/lars18th/tsduck/blob/encap-pes-mode/src/libtsduck/tsPacketEncapsulation.h#L68

You can now use for the Encapsulation the new `--pes-mode 1` (recommended) and `--pes-mode 2`; both w/o `--pack`. The Decapsulation is entirely automatic.

I created this mode because the FFmpeg tool can't use the plain encapsulation. It only process (or copies) PES packets. Therefore, this new encapsulation is necessary when used in combination with FFmpeg.

For sure, this encapsulation is **fully** tested:
1. It pass the test https://github.com/tsduck/tsduck-test/blob/master/tests/test-035.sh
2. Multiple `encap`+ `decap` files are tested with `--pes-mode 1`, `--pes-mode 1 --pack`, `--pes-mode 2` and `--pes-mode 2 --pack`.
3. Previous files are processed with FFmpeg in different ways, and after the `decap` filter is used to recovery the original content. Afterwards it's checked using the tool `tscmp`.

All problems are solved! The code is robust and tested.
Regards.