### PR TITLE
Atsc tuning fixes

### DIFF
--- a/src/libtsduck/windows/tsDirectShowUtils.cpp
+++ b/src/libtsduck/windows/tsDirectShowUtils.cpp
@@ -480,7 +480,7 @@ bool ts::CreateLocatorATSC(ComPtr<::IDigitalLocator>& locator, const TunerParame
     else {
         report.error(u"frequency %d is in neither the UHF nor VHF band", {params.frequency});
         return false;
-	}
+    }
 
     report.debug(u"mapped frequency %d to physical channel %d", {params.frequency, physical_channel});
 	

--- a/src/tsplugins/tsplugin_dvb.cpp
+++ b/src/tsplugins/tsplugin_dvb.cpp
@@ -148,6 +148,17 @@ bool ts::DVBInput::start()
     }
     tsp->debug(u"tuner reception started");
 
+    UString signal(UString::Format(u"signal locked: %s", {UString::YesNo(_tuner.signalLocked(*tsp))}));
+    int strength = _tuner.signalStrength(*tsp);
+    if (strength >= 0) {
+        signal += UString::Format(u", strength: %d%%", {strength});
+    }
+    int quality = _tuner.signalQuality(*tsp);
+    if (quality >= 0) {
+        signal += UString::Format(u", quality: %d%%", {quality});
+    }
+    tsp->verbose(signal);
+
     return true;
 }
 


### PR DESCRIPTION
I can't test actual reception yet, but I've verified that my code looks up the frequency and gets the corresponding physical channel so I'm confident it will work from my tests last weekend when the laptop was in a reception area.

However, the "--hf-band-region" does not appear to work for the tsp command, so it mapped frequency 207000000 to channel 9 which would I think be the VHF channel for Europe.