### PR TITLE
`dos2unix` is required for building on macOS

### DIFF
--- a/src/doc/building.md
+++ b/src/doc/building.md
@@ -119,7 +119,7 @@ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/
 
 - Install common open source tools using Homebrew:
 ~~~~
-brew install pcsc-lite cppunit doxygen graphviz gnu-sed grep
+brew install pcsc-lite cppunit doxygen graphviz gnu-sed grep dos2unix
 ~~~~
 
 # Building the TSDuck binaries {#buildbin}

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1239
+#define TS_COMMIT 1242


### PR DESCRIPTION
I updated a description in building.md regarding tools required for building on macOS.

When I tried to build tsduck on macOS, I got the following messages:

```
/Users/masnagam/workspace/tsduck/build/build-project-files.sh: line 268: unix2dos: command not found
/Users/masnagam/workspace/tsduck/build/build-project-files.sh: line 267: unix2dos: command not found
```

The messages can be eliminated by installing `dos2unix` like below:

```console
brew install dos2unix
```