### PR TITLE
Fix memset warning when bytes length is zero

### DIFF
--- a/src/libtsduck/tsPacketizer.cpp
+++ b/src/libtsduck/tsPacketizer.cpp
@@ -204,7 +204,9 @@ bool ts::Packetizer::getNextPacket(TSPacket& pkt)
     }
 
     // Do packet stuffing if necessary.
-    ::memset (data, 0xFF, remain_in_packet);
+    if (remain_in_packet) {
+        ::memset (data, 0xFF, remain_in_packet);
+    }
     return true;
 }
 

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1326
+#define TS_COMMIT 1327


### PR DESCRIPTION
Since 'all warnings being treated as errors' GCC 4.8 complains about memset with zero bytes length and compilation fails. Skipping memset when remain_in_packet is zero fixed the issue.

Fixes #363.