### PR TITLE
Change formula to avoid overflow

### DIFF
--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1326
+#define TS_COMMIT 1347

--- a/src/tsplugins/tsplugin_pcrverify.cpp
+++ b/src/tsplugins/tsplugin_pcrverify.cpp
@@ -216,7 +216,7 @@ namespace {
         //       = pcr2 - pcr1 - ((pkt2 - pkt1) * PKT_SIZE * 8 * SysClock / bitrate)
         //       = (bitate * (pcr2 - pcr1) - (pkt2 - pkt1) * PKT_SIZE * 8 * SysClock) / bitrate
 
-        return (bitrate * (pcr2 - pcr1) - (pkt2 - pkt1) * ts::PKT_SIZE * 8 * ts::SYSTEM_CLOCK_FREQ) / bitrate;
+        return pcr2 - pcr1 - (pkt2 - pkt1) * ts::PKT_SIZE * 8 * ts::SYSTEM_CLOCK_FREQ / bitrate;
     }
 }
 


### PR DESCRIPTION
I have trouble with the current formula when try to verify DVB-S stream with bitrate is 42249737. 
And the result is output PCR jitter is incorrect. It's always output 436,612,045,033 (or 436,612,045,032)

> * pcrverify:  Index 827,894 2019/07/17 16:20:52, PID 256 (0x0000000000000100), PCR jitter: 436,612,045,033 = 16,170,816,482 micro-seconds = 454,263,792 packets + 37 bytes + 5 bits
> * pcrverify:  Index 828,422 2019/07/17 16:20:52, PID 258 (0x0000000000000102), PCR jitter: 436,612,045,033 = 16,170,816,482 micro-seconds = 454,263,792 packets + 37 bytes + 5 bits
> * pcrverify:  Index 828,435 2019/07/17 16:20:52, PID 258 (0x0000000000000102), PCR jitter: 436,612,045,032 = 16,170,816,482 micro-seconds = 454,263,792 packets + 37 bytes + 3 bits
> * pcrverify:  Index 828,566 2019/07/17 16:20:52, PID 256 (0x0000000000000100), PCR jitter: 436,612,045,033 = 16,170,816,482 micro-seconds = 454,263,792 packets + 37 bytes + 5 bits
