### PR TITLE
Skip method that causes GCC template substitution error

### DIFF
--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1339
+#define TS_COMMIT 1340

--- a/src/libtsduck/tsxmlElement.h
+++ b/src/libtsduck/tsxmlElement.h
@@ -41,24 +41,8 @@
 #include "tsIPv6Address.h"
 #include "tsMACAddress.h"
 
-// There is a bug in GCC version 6 and 7 which prevents this file from compiling
-// correctly. This is specific to GCC 6 and 7. There is no issue with GCC 4.9, 8.x, 9.x
-// as well as MSVC and clang. The error typically appears on the latest (as of 2019)
-// versions of Debian and Raspbian, as well as obsolete versions of other distros.
-//
-// The typical symptom is the error below:
-//
-// /usr/include/c++/6/type_traits: In instantiation of 'struct std::underlying_type':
-// tsxmlElement.h:426:107: required by substitution of 'template<class ENUM, typename std::enable_if<std::is_enum<_Tp>::value>::type* , class INT> bool ts::xml::Element::getIntAttribute(ENUM&, const ts::UString&, bool, ENUM, INT, INT) const [with ENUM = unsigned char; typename std::enable_if<std::is_enum<_Tp>::value>::type* = ; INT = ]'
-// tsAACDescriptor.cpp:186:88: required from here
-// /usr/include/c++/6/type_traits:2256:38: error: 'unsigned char' is not an enumeration type
-// typedef __underlying_type(_Tp) type;
-//
-// There is no other solution than switching to a fixed version of GCC.
-// See https://tsduck.io/doxy/building.html#reqraspbian
-
 #if defined(TS_GCC_ONLY) && !defined(TS_IGNORE_GCC6_BUG) && (__GNUC__ == 6 || __GNUC__ == 7)
-#error "GCC versions 6 and 7 are broken and fail to properly handle some template substitutions, use another version of GCC, see https://tsduck.io/doxy/building.html#reqraspbian"
+#pragma message "GCC versions 6 and 7 are broken and fail to properly handle some template substitutions, prefer using another version of GCC, see https://tsduck.io/doxy/building.html#reqraspbian"
 #endif
 
 namespace ts {
@@ -433,6 +417,7 @@ namespace ts {
                                  INT minValue = std::numeric_limits<INT>::min(),
                                  INT maxValue = std::numeric_limits<INT>::max()) const;
 
+#if !defined(TS_GCC_ONLY) || defined(TS_IGNORE_GCC6_BUG) || !(__GNUC__ == 6 || __GNUC__ == 7)
             //!
             //! Get an integer attribute of an XML element in an enum type.
             //! @tparam ENUM An enumeration type.
@@ -451,6 +436,7 @@ namespace ts {
                                  ENUM defValue = 0,
                                  INT minValue = 0,
                                  INT maxValue = std::numeric_limits<INT>::max()) const;
+#endif
 
             //!
             //! Get an optional integer attribute of an XML element.

--- a/src/libtsduck/tsxmlElementTemplate.h
+++ b/src/libtsduck/tsxmlElementTemplate.h
@@ -61,6 +61,7 @@ bool ts::xml::Element::getIntAttribute(INT& value, const UString& name, bool req
     }
 }
 
+#if !defined(TS_GCC_ONLY) || defined(TS_IGNORE_GCC6_BUG) || !(__GNUC__ == 6 || __GNUC__ == 7)
 template <typename ENUM, typename std::enable_if<std::is_enum<ENUM>::value>::type*, typename INT>
 bool ts::xml::Element::getIntAttribute(ENUM& value, const UString& name, bool required, ENUM defValue, INT minValue, INT maxValue) const
 {
@@ -71,6 +72,7 @@ bool ts::xml::Element::getIntAttribute(ENUM& value, const UString& name, bool re
     }
     return ok;
 }
+#endif
 
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
As an Ubuntu 18.04 user I eventually ran into #219. Here is my `gcc --version` output:

```
$ gcc --version
gcc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

I know that the workaround of using GCC version other than 6 and 7 seems OK but it looks an interesting issue to solve. I tried to dig into it but didn't find a proper solution except to skip the method that causes the error. Since this method is overloaded, client code will rely on them. WDYT?

I ran the test suite and it seemed fine:

```
$ make -j8 NOPCSC=1 NODTAPI=1
$ source ./src/utest/release-x86_64/setenv.sh ./src/tstools/release-x86_64/setenv.sh
$ ./src/utest/release-x86_64/utest && ./src/utest/release-x86_64/utest_static 

OK (390 tests, 8611 assertions)


OK (387 tests, 8599 assertions)
```

Hope it helps.