### PR TITLE
Small libsrt changes

### DIFF
--- a/Makefile.tsduck
+++ b/Makefile.tsduck
@@ -106,7 +106,7 @@ endif
 
 ifeq ($(MACOS)$(NOSRT),)
     # Not on macOS and SRT not disabled, check if libsrt is available.
-    NOSRT = $(if $(wildcard /usr/include/srt/*.h),,true)
+    NOSRT = $(if $(wildcard /usr/include/srt/*.h)$(wildcard /usr/local/include/srt/*.h),,true)
 endif
 
 ifneq ($(NOSRT),)

--- a/src/libtsduck/base/network/tsSRTSocket.cpp
+++ b/src/libtsduck/base/network/tsSRTSocket.cpp
@@ -450,7 +450,7 @@ bool ts::SRTSocket::setSockOptPre(ts::Report& report)
 
     if ((_mode != SRTSocketMode::CALLER && !setSockOpt(SRTO_SENDER, "SRTO_SENDER", &yes, sizeof(yes), report)) ||
         (_transtype != SRTT_INVALID && !setSockOpt(SRTO_TRANSTYPE, "SRTO_TRANSTYPE", &_transtype, sizeof(_transtype), report)) ||
-        (_messageapi && !setSockOpt(SRTO_MESSAGEAPI, "SRTO_MESSAGEAPI", &msgapi, sizeof(msgapi), report)) ||
+        (!setSockOpt(SRTO_MESSAGEAPI, "SRTO_MESSAGEAPI", &msgapi, sizeof(msgapi), report)) ||
         (_conn_timeout >= 0 && !setSockOpt(SRTO_CONNTIMEO, "SRTO_CONNTIMEO", &_conn_timeout, sizeof(_conn_timeout), report)) ||
         (_ffs > 0 && !setSockOpt(SRTO_FC, "SRTO_FC", &_ffs, sizeof(_ffs), report)) ||
         (_iptos >= 0 && !setSockOpt(SRTO_IPTOS, "SRTO_IPTOS", &_iptos, sizeof(_iptos), report)) ||

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1604
+#define TS_COMMIT 1606

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1606
+#define TS_COMMIT 1608

--- a/src/libtsduck/tsduck.mk
+++ b/src/libtsduck/tsduck.mk
@@ -57,7 +57,7 @@ ifdef TS_MAC
     endif
 else
     TS_INCLUDES += -I/usr/include/PCSC -I$(TS_INCLUDE_DIR)
-    ifeq ($(wildcard /usr/include/srt/*.h),)
+    ifeq ($(wildcard /usr/include/srt/*.h)$(wildcard /usr/local/include/srt/*.h),)
         CFLAGS += -DTS_NOSRT=1
     else
        LDLIBS += -lsrt


### PR DESCRIPTION
I made two small changes:
* always set messageapi option. It is true by default and we need to be able to turn it off if we want.
* check for locally compiled/installed libsrt in /usr/local/include for NOSRT setting