### PR TITLE
Kernel legacy compatibility 

### DIFF
--- a/src/libtsduck/base/tsPlatform.h
+++ b/src/libtsduck/base/tsPlatform.h
@@ -858,6 +858,7 @@ TS_MSC_NOWARNING(5027)
 #include <linux/dvb/version.h>
 #include <linux/dvb/frontend.h>
 #include <linux/dvb/dmx.h>
+#include <linux/version.h>
 #endif
 
 #if defined(TS_MAC)

--- a/src/libtsduck/dtv/linux/tsDTVProperties.h
+++ b/src/libtsduck/dtv/linux/tsDTVProperties.h
@@ -36,6 +36,10 @@
 #include "tsReport.h"
 #include "tsVariable.h"
 
+#if !defined(NO_STREAM_ID_FILTER)
+#define NO_STREAM_ID_FILTER    (~0U)
+#endif
+
 namespace ts {
     //!
     //! Encapsulation of Linux DVB property lists.

--- a/src/libtsduck/dtv/linux/tsTunerGuts.cpp
+++ b/src/libtsduck/dtv/linux/tsTunerGuts.cpp
@@ -540,7 +540,9 @@ bool ts::Tuner::Guts::getCurrentTuning(ModulationArgs& params, bool reset_unknow
             props.add(DTV_MODULATION);
             props.add(DTV_PILOT);
             props.add(DTV_ROLLOFF);
+#if defined(DTV_STREAM_ID)
             props.add(DTV_STREAM_ID);
+#endif
 
             if (::ioctl(frontend_fd, ioctl_request_t(FE_GET_PROPERTY), props.getIoctlParam()) < 0) {
                 const ErrorCode err = LastErrorCode();
@@ -556,7 +558,11 @@ bool ts::Tuner::Guts::getCurrentTuning(ModulationArgs& params, bool reset_unknow
             params.roll_off = RollOff(props.getByCommand(DTV_ROLLOFF));
 
             // With the Linux DVB API, all multistream selection info are passed in the "stream id".
+#if defined(DTV_STREAM_ID)
             const uint32_t id = props.getByCommand(DTV_STREAM_ID);
+#else
+            const uint32_t id = NO_STREAM_ID_FILTER;
+#endif
             params.isi = id & 0x000000FF;
             params.pls_code = (id >> 8) & 0x0003FFFF;
             params.pls_mode = PLSMode(id >> 26);
@@ -574,7 +580,9 @@ bool ts::Tuner::Guts::getCurrentTuning(ModulationArgs& params, bool reset_unknow
             props.add(DTV_TRANSMISSION_MODE);
             props.add(DTV_GUARD_INTERVAL);
             props.add(DTV_HIERARCHY);
+#if defined(DTV_STREAM_ID)
             props.add(DTV_STREAM_ID);
+#endif
 
             if (::ioctl(frontend_fd, ioctl_request_t(FE_GET_PROPERTY), props.getIoctlParam()) < 0) {
                 const ErrorCode err = LastErrorCode();
@@ -591,7 +599,11 @@ bool ts::Tuner::Guts::getCurrentTuning(ModulationArgs& params, bool reset_unknow
             params.transmission_mode = TransmissionMode(props.getByCommand(DTV_TRANSMISSION_MODE));
             params.guard_interval = GuardInterval(props.getByCommand(DTV_GUARD_INTERVAL));
             params.hierarchy = Hierarchy(props.getByCommand(DTV_HIERARCHY));
+#if defined(DTV_STREAM_ID)
             params.plp = props.getByCommand(DTV_STREAM_ID);
+#else
+            params.plp = NO_STREAM_ID_FILTER;
+#endif
             return true;
         }
         case DS_DVB_C_ANNEX_A:
@@ -1013,7 +1025,9 @@ bool ts::Tuner::tune(ModulationArgs& params, Report& report)
                     ((params.pls_code.value(ModulationArgs::DEFAULT_PLS_CODE) & 0x0003FFFF) << 8) |
                     (params.isi.value() & 0x000000FF);
                 report.debug(u"using DVB-S2 multi-stream id 0x%X (%d)", {id, id});
+#if defined(DTV_STREAM_ID)
                 props.add(DTV_STREAM_ID, id);
+#endif
             }
             break;
         }
@@ -1029,7 +1043,9 @@ bool ts::Tuner::tune(ModulationArgs& params, Report& report)
             props.addVar(DTV_TRANSMISSION_MODE, params.transmission_mode);
             props.addVar(DTV_GUARD_INTERVAL, params.guard_interval);
             props.addVar(DTV_HIERARCHY, params.hierarchy);
+#if defined(DTV_STREAM_ID)
             props.addVar(DTV_STREAM_ID, params.plp);
+#endif
             break;
         }
         case DS_DVB_C_ANNEX_A:

--- a/src/libtsduck/dtv/linux/tsTunerGuts.cpp
+++ b/src/libtsduck/dtv/linux/tsTunerGuts.cpp
@@ -324,11 +324,15 @@ bool ts::Tuner::open(const UString& device_name, bool info_only, Report& report)
 
     _delivery_systems.clear();
     DTVProperties props;
+#if defined(DTV_ENUM_DELSYS)
     props.add(DTV_ENUM_DELSYS);
     if (::ioctl(_guts->frontend_fd, ioctl_request_t(FE_GET_PROPERTY), props.getIoctlParam()) >= 0) {
         // DTV_ENUM_DELSYS succeeded, get all delivery systems.
         props.getValuesByCommand(_delivery_systems, DTV_ENUM_DELSYS);
     }
+#else
+    if (0) {;}
+#endif
     else {
         // DTV_ENUM_DELSYS failed, convert tuner type from FE_GET_INFO.
         const ErrorCode err = LastErrorCode();

--- a/src/libtsduck/dtv/linux/tsTunerGuts.cpp
+++ b/src/libtsduck/dtv/linux/tsTunerGuts.cpp
@@ -1581,7 +1581,11 @@ std::ostream& ts::Tuner::displayStatus(std::ostream& strm, const ts::UString& ma
         {u"8-VSB",                  ::FE_CAN_8VSB},
         {u"16-VSB",                 ::FE_CAN_16VSB},
         {u"extended caps",          ::FE_HAS_EXTENDED_CAPS},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0)
+        {u"multistream",            int(0x4000000)},
+#else
         {u"multistream",            ::FE_CAN_MULTISTREAM},
+#endif
         {u"turbo FEC",              ::FE_CAN_TURBO_FEC},
         {u"2nd generation",         ::FE_CAN_2G_MODULATION},
         {u"needs bending",          ::FE_NEEDS_BENDING},

--- a/src/libtsduck/dtv/tsDeliverySystem.h
+++ b/src/libtsduck/dtv/tsDeliverySystem.h
@@ -50,8 +50,14 @@ namespace ts {
         DS_DVB_S_TURBO   = ::SYS_TURBO,
         DS_DVB_T         = ::SYS_DVBT,
         DS_DVB_T2        = ::SYS_DVBT2,
+#if !defined(SYS_DVBC_ANNEX_A)
+#define SYS_DVBC_ANNEX_A     SYS_DVBC_ANNEX_AC
+#endif
         DS_DVB_C_ANNEX_A = ::SYS_DVBC_ANNEX_A,
         DS_DVB_C_ANNEX_B = ::SYS_DVBC_ANNEX_B,
+#if !defined(SYS_DVBC_ANNEX_C)
+#define SYS_DVBC_ANNEX_C     SYS_DVBC_ANNEX_AC
+#endif
         DS_DVB_C_ANNEX_C = ::SYS_DVBC_ANNEX_C,
         DS_DVB_C2        = -10,
         DS_DVB_H         = ::SYS_DVBH,
@@ -60,6 +66,9 @@ namespace ts {
         DS_ISDB_C        = ::SYS_ISDBC,
         DS_ATSC          = ::SYS_ATSC,
         DS_ATSC_MH       = ::SYS_ATSCMH,
+#if !defined(SYS_DTMB)
+#define SYS_DTMB             SYS_DMBTH
+#endif
         DS_DTMB          = ::SYS_DTMB,
         DS_CMMB          = ::SYS_CMMB,
         DS_DAB           = ::SYS_DAB,

--- a/src/libtsduck/dtv/tsDeliverySystem.h
+++ b/src/libtsduck/dtv/tsDeliverySystem.h
@@ -50,15 +50,17 @@ namespace ts {
         DS_DVB_S_TURBO   = ::SYS_TURBO,
         DS_DVB_T         = ::SYS_DVBT,
         DS_DVB_T2        = ::SYS_DVBT2,
-#if !defined(SYS_DVBC_ANNEX_A)
-#define SYS_DVBC_ANNEX_A     SYS_DVBC_ANNEX_AC
-#endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,3,0)
+        DS_DVB_C_ANNEX_A = ::SYS_DVBC_ANNEX_AC,
+#else
         DS_DVB_C_ANNEX_A = ::SYS_DVBC_ANNEX_A,
-        DS_DVB_C_ANNEX_B = ::SYS_DVBC_ANNEX_B,
-#if !defined(SYS_DVBC_ANNEX_C)
-#define SYS_DVBC_ANNEX_C     SYS_DVBC_ANNEX_AC
 #endif
+        DS_DVB_C_ANNEX_B = ::SYS_DVBC_ANNEX_B,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,3,0)
+        DS_DVB_C_ANNEX_C = -11,
+#else
         DS_DVB_C_ANNEX_C = ::SYS_DVBC_ANNEX_C,
+#endif
         DS_DVB_C2        = -10,
         DS_DVB_H         = ::SYS_DVBH,
         DS_ISDB_S        = ::SYS_ISDBS,
@@ -66,8 +68,10 @@ namespace ts {
         DS_ISDB_C        = ::SYS_ISDBC,
         DS_ATSC          = ::SYS_ATSC,
         DS_ATSC_MH       = ::SYS_ATSCMH,
-#if !defined(SYS_DTMB)
-#define SYS_DTMB             SYS_DMBTH
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0)
+        DS_DTMB          = ::SYS_DMBTH,
+#else
+        DS_DTMB          = ::SYS_DTMB,
 #endif
         DS_DTMB          = ::SYS_DTMB,
         DS_CMMB          = ::SYS_CMMB,

--- a/src/libtsduck/dtv/tsDeliverySystem.h
+++ b/src/libtsduck/dtv/tsDeliverySystem.h
@@ -73,7 +73,6 @@ namespace ts {
 #else
         DS_DTMB          = ::SYS_DTMB,
 #endif
-        DS_DTMB          = ::SYS_DTMB,
         DS_CMMB          = ::SYS_CMMB,
         DS_DAB           = ::SYS_DAB,
         DS_DSS           = ::SYS_DSS,

--- a/src/libtsduck/dtv/tsModulation.h
+++ b/src/libtsduck/dtv/tsModulation.h
@@ -108,7 +108,11 @@ namespace ts {
         APSK_16  = ::APSK_16,
         APSK_32  = ::APSK_32,
         DQPSK    = ::DQPSK,
+#if !defined(QAM_4_NR)
+        QAM_4_NR = -14,
+#else
         QAM_4_NR = ::QAM_4_NR,
+#endif
 #elif defined(TS_WINDOWS) && !defined(DOXYGEN)
         QPSK     = ::BDA_MOD_QPSK,
         PSK_8    = ::BDA_MOD_8PSK,
@@ -197,7 +201,11 @@ namespace ts {
         FEC_3_5  = ::FEC_3_5,
         FEC_1_3  = -12,
         FEC_1_4  = -13,
+#if !defined(FEC_2_5)
+        FEC_2_5  = -14,
+#else
         FEC_2_5  = ::FEC_2_5,
+#endif
         FEC_5_11 = -15,
 #elif defined(TS_WINDOWS) && !defined(DOXYGEN)
         FEC_NONE = ::BDA_BCC_RATE_NOT_SET,
@@ -396,8 +404,16 @@ namespace ts {
         TM_1K    = ::TRANSMISSION_MODE_1K,
         TM_16K   = ::TRANSMISSION_MODE_16K,
         TM_32K   = ::TRANSMISSION_MODE_32K,
+#if !defined(TRANSMISSION_MODE_C1)
+        TM_C1    = -12,
+#else
         TM_C1    = ::TRANSMISSION_MODE_C1,
+#endif
+#if !defined(TRANSMISSION_MODE_C3780)
+        TM_C3780 = -13,
+#else
         TM_C3780 = ::TRANSMISSION_MODE_C3780,
+#endif
 #elif defined(TS_WINDOWS) && !defined(DOXYGEN)
         TM_AUTO  = ::BDA_XMIT_MODE_NOT_DEFINED,
         TM_2K    = ::BDA_XMIT_MODE_2K,
@@ -443,9 +459,21 @@ namespace ts {
         GUARD_1_128  = ::GUARD_INTERVAL_1_128,
         GUARD_19_128 = ::GUARD_INTERVAL_19_128,
         GUARD_19_256 = ::GUARD_INTERVAL_19_256,
+#if !defined(GUARD_INTERVAL_PN420)
+        GUARD_PN420  = -9,
+#else
         GUARD_PN420  = ::GUARD_INTERVAL_PN420,
+#endif
+#if !defined(GUARD_INTERVAL_PN595)
+        GUARD_PN595  = -10,
+#else
         GUARD_PN595  = ::GUARD_INTERVAL_PN595,
+#endif
+#if !defined(GUARD_INTERVAL_PN945)
+        GUARD_PN945  = -11,
+#else
         GUARD_PN945  = ::GUARD_INTERVAL_PN945,
+#endif
 #elif defined(TS_WINDOWS) && !defined(DOXYGEN)
         GUARD_AUTO   = ::BDA_GUARD_NOT_DEFINED,
         GUARD_1_32   = ::BDA_GUARD_1_32,

--- a/src/libtsduck/dtv/tsModulation.h
+++ b/src/libtsduck/dtv/tsModulation.h
@@ -108,7 +108,7 @@ namespace ts {
         APSK_16  = ::APSK_16,
         APSK_32  = ::APSK_32,
         DQPSK    = ::DQPSK,
-#if !defined(QAM_4_NR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0)
         QAM_4_NR = -14,
 #else
         QAM_4_NR = ::QAM_4_NR,
@@ -201,11 +201,12 @@ namespace ts {
         FEC_3_5  = ::FEC_3_5,
         FEC_1_3  = -12,
         FEC_1_4  = -13,
-#if !defined(FEC_2_5)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0)
         FEC_2_5  = -14,
 #else
         FEC_2_5  = ::FEC_2_5,
 #endif
+        FEC_5_11 = -15,
         FEC_5_11 = -15,
 #elif defined(TS_WINDOWS) && !defined(DOXYGEN)
         FEC_NONE = ::BDA_BCC_RATE_NOT_SET,
@@ -404,14 +405,11 @@ namespace ts {
         TM_1K    = ::TRANSMISSION_MODE_1K,
         TM_16K   = ::TRANSMISSION_MODE_16K,
         TM_32K   = ::TRANSMISSION_MODE_32K,
-#if !defined(TRANSMISSION_MODE_C1)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0)
         TM_C1    = -12,
-#else
-        TM_C1    = ::TRANSMISSION_MODE_C1,
-#endif
-#if !defined(TRANSMISSION_MODE_C3780)
         TM_C3780 = -13,
 #else
+        TM_C1    = ::TRANSMISSION_MODE_C1,
         TM_C3780 = ::TRANSMISSION_MODE_C3780,
 #endif
 #elif defined(TS_WINDOWS) && !defined(DOXYGEN)
@@ -459,19 +457,13 @@ namespace ts {
         GUARD_1_128  = ::GUARD_INTERVAL_1_128,
         GUARD_19_128 = ::GUARD_INTERVAL_19_128,
         GUARD_19_256 = ::GUARD_INTERVAL_19_256,
-#if !defined(GUARD_INTERVAL_PN420)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0)
         GUARD_PN420  = -9,
-#else
-        GUARD_PN420  = ::GUARD_INTERVAL_PN420,
-#endif
-#if !defined(GUARD_INTERVAL_PN595)
         GUARD_PN595  = -10,
-#else
-        GUARD_PN595  = ::GUARD_INTERVAL_PN595,
-#endif
-#if !defined(GUARD_INTERVAL_PN945)
         GUARD_PN945  = -11,
 #else
+        GUARD_PN420  = ::GUARD_INTERVAL_PN420,
+        GUARD_PN595  = ::GUARD_INTERVAL_PN595,
         GUARD_PN945  = ::GUARD_INTERVAL_PN945,
 #endif
 #elif defined(TS_WINDOWS) && !defined(DOXYGEN)

--- a/src/libtsduck/dtv/tsModulation.h
+++ b/src/libtsduck/dtv/tsModulation.h
@@ -207,7 +207,6 @@ namespace ts {
         FEC_2_5  = ::FEC_2_5,
 #endif
         FEC_5_11 = -15,
-        FEC_5_11 = -15,
 #elif defined(TS_WINDOWS) && !defined(DOXYGEN)
         FEC_NONE = ::BDA_BCC_RATE_NOT_SET,
         FEC_AUTO = ::BDA_BCC_RATE_NOT_DEFINED,


### PR DESCRIPTION
Restore compatbility with some legacy kernels (linux 3.2) because some missing declarations.