### PR TITLE
libsrt: update after srt_socket deprecation

### DIFF
--- a/src/libtsduck/base/network/tsSRTSocket.cpp
+++ b/src/libtsduck/base/network/tsSRTSocket.cpp
@@ -475,8 +475,12 @@ bool ts::SRTSocket::open(SRTSocketMode mode,
 
     _guts->mode = mode;
 
+#if SRT_VERSION_VALUE >= SRT_MAKE_VERSION_VALUE(1, 4, 1)
+    _guts->sock = srt_create_socket();
+#else
     // Only supports IPv4.
     _guts->sock = srt_socket(AF_INET, SOCK_DGRAM, 0);
+#endif
     if (_guts->sock < 0) {
         report.error(u"error during srt_socket(), msg: %s", { srt_getlasterror_str() });
         return false;

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1630
+#define TS_COMMIT 1634


### PR DESCRIPTION
srt_socket deprecated since commit eef66e53 and replaced by
srt_create_socket.