### PR TITLE
Update Makefile.common

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -606,7 +606,7 @@ ROOTDIR := $(abspath $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST)))))
 SUBDIRS = $(sort $(patsubst %/,%,$(wildcard */)))
 
 # List of subdirectories to ignore in make recursion.
-NORECURSE_SUBDIRS += tmp debug release debug-% release-% Debug Release Debug-% Release-% .vs ipch %.t2d .git cov-int
+NORECURSE_SUBDIRS += tmp bin debug release debug-% release-% Debug Release Debug-% Release-% .vs ipch %.t2d .git cov-int
 
 # Actual recurse order. If the user did not define RECURSE_ORDER, use all
 # subdirectories, except those for which we know there is nothing to make.


### PR DESCRIPTION
When some unkown directory exists inside the tsduck main directory the compilation fails.
So, overcome any `./bin` if the user has created one.