### PR TITLE
Parse and display SEI pic_timing

### DIFF
--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1652
+#define TS_COMMIT 1656

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1656
+#define TS_COMMIT 1657

--- a/src/tsplugins/tsplugin_pes.cpp
+++ b/src/tsplugins/tsplugin_pes.cpp
@@ -596,7 +596,7 @@ void ts::PESPlugin::handleSEI(PESDemux& demux, const PESPacket& pkt, uint32_t se
                 }
              }
           }
-          timecode << (int)h << ":" << (int)m << ":" << (int)s << "." << (int)n_frames;
+          timecode << int(h) << ":" << int(m) << ":" << int(s) << "." << int(n_frames);
           DISS(timecode, timecode.str());
        }
 #undef DISS

--- a/src/tsplugins/tsplugin_pes.cpp
+++ b/src/tsplugins/tsplugin_pes.cpp
@@ -558,19 +558,19 @@ void ts::PESPlugin::handleSEI(PESDemux& demux, const PESPacket& pkt, uint32_t se
        bs.skip(15);
        uint8_t pic_struct = bs.read<uint8_t>(4);
        DISP(pic_struct);
-       bool clock_timestamp_flag = bs.readBit();
+       uint8_t clock_timestamp_flag = bs.readBit();
        if (clock_timestamp_flag)
        {
           uint8_t ct_type = bs.read<uint8_t>(2);
           DISP(ct_type);
-          bool nuit_field_based_flag = bs.readBit();
+          uint8_t nuit_field_based_flag = bs.readBit();
           DISP(nuit_field_based_flag);
           uint8_t counting_type = bs.read<uint8_t>(5);
           DISP(counting_type);
-          bool full_timestamp_flag = bs.readBit();
-          bool discontinuity_flag = bs.readBit();
+          uint8_t full_timestamp_flag = bs.readBit();
+          uint8_t discontinuity_flag = bs.readBit();
           DISP(discontinuity_flag);
-          bool cnt_dropped_flag = bs.readBit();
+          uint8_t cnt_dropped_flag = bs.readBit();
           DISP(cnt_dropped_flag);
           uint8_t n_frames = bs.read<uint8_t>(8);
           std::stringstream timecode;


### PR DESCRIPTION
This PR adds code to parse and display the field of AVC SEI pic_timing. I'm not sure if its the right location for that code, but that's a feature I would lke tsduck to contain.