### PR TITLE
Inject time signal at specific time using splice time and start delay

### DIFF
--- a/src/tsplugins/tsplugin_spliceinject.cpp
+++ b/src/tsplugins/tsplugin_spliceinject.cpp
@@ -799,6 +799,9 @@ ts::SpliceInjectPlugin::SpliceCommand::SpliceCommand(SpliceInjectPlugin* plugin,
             next_pts = (last_pts - preceding) & PTS_DTS_MASK;
         }
     }
+    else if (sit.isValid() && sit.splice_command_type == SPLICE_TIME_SIGNAL) {
+       next_pts = sit.time_signal.value() - 90000*4;
+    }
 }
 
 

--- a/src/tsplugins/tsplugin_spliceinject.cpp
+++ b/src/tsplugins/tsplugin_spliceinject.cpp
@@ -769,23 +769,31 @@ ts::SpliceInjectPlugin::SpliceCommand::SpliceCommand(SpliceInjectPlugin* plugin,
 
     // The initial values for the member fields are set for one immediate injection.
     // This must be changed for non-immediate splice insert commands.
-    if (sit.isValid() && sit.splice_command_type == SPLICE_INSERT && !sit.splice_insert.canceled && !sit.splice_insert.immediate) {
+    if (sit.isValid() && ((sit.splice_command_type == SPLICE_TIME_SIGNAL) || 
+        (sit.splice_command_type == SPLICE_INSERT && !sit.splice_insert.canceled && !sit.splice_insert.immediate))) {
         // Compute the splice event PTS value. This will be the last time for
         // the splice command injection since the event is obsolete afterward.
-        if (sit.splice_insert.program_splice) {
-            // Common PTS value, program-wide.
-            if (sit.splice_insert.program_pts.set()) {
-                last_pts = sit.splice_insert.program_pts.value();
+        if (sit.splice_command_type == SPLICE_INSERT) {
+            if (sit.splice_insert.program_splice) {
+                // Common PTS value, program-wide.
+                if (sit.splice_insert.program_pts.set()) {
+                    last_pts = sit.splice_insert.program_pts.value();
+                }
             }
-        }
-        else {
-            // Compute the earliest PTS in all components.
-            for (auto it = sit.splice_insert.components_pts.begin(); it != sit.splice_insert.components_pts.end(); ++it) {
-                if (it->second.set()) {
-                    if (last_pts == INVALID_PTS || SequencedPTS(it->second.value(), last_pts)) {
-                        last_pts = it->second.value();
+            else {
+                // Compute the earliest PTS in all components.
+                for (auto it = sit.splice_insert.components_pts.begin(); it != sit.splice_insert.components_pts.end(); ++it) {
+                    if (it->second.set()) {
+                        if (last_pts == INVALID_PTS || SequencedPTS(it->second.value(), last_pts)) {
+                            last_pts = it->second.value();
+                        }
                     }
                 }
+            }
+        }
+        else if (sit.splice_command_type == SPLICE_TIME_SIGNAL) {
+            if (sit.time_signal.set()) {
+                last_pts = sit.time_signal.value();
             }
         }
         // If we could not find the event PTS, keep one single immediate injection.
@@ -798,9 +806,6 @@ ts::SpliceInjectPlugin::SpliceCommand::SpliceCommand(SpliceInjectPlugin* plugin,
             // Compute the first PTS time for injection.
             next_pts = (last_pts - preceding) & PTS_DTS_MASK;
         }
-    }
-    else if (sit.isValid() && sit.splice_command_type == SPLICE_TIME_SIGNAL) {
-       next_pts = sit.time_signal.value() - 90000*4;
     }
 }
 


### PR DESCRIPTION
The aim of this PR is to inject time_signal 4s before pts_time instead of right at the beginning.
The spliceinject filter options used are : -P spliceinject --service 1545  --inject-count 1 --files '/tmp/splices000.xml' --wait-first-batch

splices000.xml contained this : 
```
 <splice_information_table>
 <time_signal pts_time="6957864362" />
 <splice_segmentation_descriptor segmentation_event_id="100" segmentation_type_id="0x24" segment_num="1" segments_expected="1">
 <segmentation_upid type="0"/>
 </splice_segmentation_descriptor>
 </splice_information_table>
```