### PR TITLE
Use user's system-wide LD_LIBRARY_PATH

### DIFF
--- a/src/tstools/Makefile
+++ b/src/tstools/Makefile
@@ -54,7 +54,7 @@ endif
 
 $(OBJDIR)/setenv.sh: Makefile
 	echo '[[ ":$$PATH:" != *:$(realpath $(OBJDIR)):* ]] && export PATH="$(realpath $(OBJDIR)):$$PATH"' >$@
-	echo 'export LD_LIBRARY_PATH="$(realpath $(LIBTSDUCKDIR)/$(OBJDIR))"' >>$@
+	echo 'export LD_LIBRARY_PATH="$(realpath $(LIBTSDUCKDIR)/$(OBJDIR)):$LD_LIBRARY_PATH"' >>$@
 	echo 'export TSPLUGINS_PATH=$(realpath $(TSPLUGINSDIR)/$(OBJDIR)):$(realpath $(LIBTSDUCKDIR)/dtv)' >>$@
 
 .PHONY: install install-devel

--- a/src/utest/Makefile
+++ b/src/utest/Makefile
@@ -51,7 +51,7 @@ $(OBJDIR)/utest_static: $(subst $(OBJDIR)/utestPlugin.o,,$(OBJS)) $(LIBTSDUCKDIR
 # A script to create the appropriate execution environment.
 $(OBJDIR)/setenv.sh: Makefile
 	echo '[[ ":$$PATH:" != *:$(realpath $(OBJDIR)):* ]] && export PATH="$(realpath $(OBJDIR)):$$PATH"' >$@
-	echo 'export LD_LIBRARY_PATH="$(realpath $(LIBTSDUCKDIR)/$(OBJDIR))"' >>$@
+	echo 'export LD_LIBRARY_PATH="$(realpath $(LIBTSDUCKDIR)/$(OBJDIR)):$LD_LIBRARY_PATH"' >>$@
 	echo 'export TSPLUGINS_PATH="$(realpath $(TSPLUGINSDIR)/$(OBJDIR)):$(realpath $(LIBTSDUCKDIR)/dtv)"' >>$@
 
 .PHONY: test


### PR DESCRIPTION
When the user has the LD_LIBRARY_PATH defined, use it in the `setenv.sh`. If not then the execution fails if some used library isn't in the standard path.
