### PR TITLE
Protected2 and copy constructor continuity analyzer

### DIFF
--- a/src/libtsduck/dtv/tsContinuityAnalyzer.cpp
+++ b/src/libtsduck/dtv/tsContinuityAnalyzer.cpp
@@ -134,7 +134,7 @@ bool ts::ContinuityAnalyzer::hasPID(PID pid) const
 
 
 //----------------------------------------------------------------------------
-// Get the first and last CC in a PID.
+// PIDState access
 //----------------------------------------------------------------------------
 
 uint8_t ts::ContinuityAnalyzer::firstCC(PID pid) const
@@ -147,6 +147,18 @@ uint8_t ts::ContinuityAnalyzer::lastCC(PID pid) const
 {
     auto it = _pid_states.find(pid);
     return it == _pid_states.end() ? INVALID_CC : it->second.last_cc_out;
+}
+
+size_t ts::ContinuityAnalyzer::dupCount(PID pid) const
+{
+    auto it = _pid_states.find(pid);
+    return it == _pid_states.end() ? NPOS : it->second.dup_count;
+}
+
+ts::TSPacket ts::ContinuityAnalyzer::lastPacket(PID pid) const
+{
+    auto it = _pid_states.find(pid);
+    return it == _pid_states.end() ? NullPacket : it->second.last_pkt_in;
 }
 
 

--- a/src/libtsduck/dtv/tsContinuityAnalyzer.h
+++ b/src/libtsduck/dtv/tsContinuityAnalyzer.h
@@ -44,7 +44,6 @@ namespace ts {
     //!
     class TSDUCKDLL ContinuityAnalyzer
     {
-        TS_NOCOPY(ContinuityAnalyzer);
     public:
         //!
         //! Constructor.

--- a/src/libtsduck/dtv/tsContinuityAnalyzer.h
+++ b/src/libtsduck/dtv/tsContinuityAnalyzer.h
@@ -195,6 +195,20 @@ namespace ts {
         uint8_t lastCC(PID pid) const;
 
         //!
+        //! Get the last duplicate packet count for a PID.
+        //! @param [in] pid The PID to check.
+        //! @return The last duplicate packet count for the PID or ts::NPOS when the PID is not filtered.
+        //!
+        size_t dupCount(PID pid) const;
+
+        //!
+        //! Get the last transport stream packet (that was passed to @ref feedPacket) for a PID.
+        //! @param [in] pid The PID to check.
+        //! @return The last packet for the PID or ts::NullPacket when the PID is not filtered.
+        //!
+        TSPacket lastPacket(PID pid) const;
+
+        //!
         //! Compute the number of missing packets between two continuity counters.
         //! @param [in] cc1 First continuity counter.
         //! @param [in] cc2 Second continuity counter.


### PR DESCRIPTION
Rather than expose PIDState, I opted to just expose the per-PID duplicate count and last packet.  There were already methods for exposing the first and last CCs.

The enablement of the copy constructor is needed for forward packet CC analysis without affecting the "main" ContinuityCounter object for a stream.