### PR TITLE
Improve interrupt handling on Windows and allow termination via text …

### DIFF
--- a/src/libtsduck/base/tsUserInterrupt.h
+++ b/src/libtsduck/base/tsUserInterrupt.h
@@ -49,9 +49,7 @@ namespace ts {
     //! - Interrupt polling through isInterrupted()/resetInterrupted().
     //!
     class TSDUCKDLL UserInterrupt
-#if defined(TS_UNIX)
         : private Thread
-#endif
     {
         TS_NOBUILD_NOCOPY(UserInterrupt);
     public:
@@ -107,13 +105,13 @@ namespace ts {
 #if defined(TS_WINDOWS)
 
         static ::BOOL WINAPI sysHandler(__in ::DWORD dwCtrlType);
+        void main() override;  // ts::Thread implementation
 
 #elif defined(TS_UNIX)
 
         static void sysHandler(int sig);
         virtual void main() override;  // ts::Thread implementation
 
-        volatile bool           _terminate;
         volatile ::sig_atomic_t _got_sigint;
 #if defined(TS_MAC)
         std::string             _sem_name;
@@ -124,6 +122,7 @@ namespace ts {
 
 #endif
 
+        volatile bool           _terminate;
         InterruptHandler* _handler;
         bool              _one_shot;
         bool              _active;

--- a/src/tstools/tsp.cpp
+++ b/src/tstools/tsp.cpp
@@ -191,7 +191,7 @@ int MainCode(int argc, char *argv[])
 
     // Use a Ctrl+C interrupt handler
     TSPInterruptHandler interrupt_handler(&report, &tsproc);
-    ts::UserInterrupt interrupt_manager(&interrupt_handler, true, true);
+    ts::UserInterrupt interrupt_manager(&interrupt_handler, false, true);
 
     // Start the TS processing.
     if (!tsproc.start(opt.tsp_args)) {


### PR DESCRIPTION
This PR includes three closely related changes for shutdown handling on Windows:

### 1. Fix CTRL-C Handler not working

To reproduce:

- Run tsp.exe from the command line
  (without any arguments)
- Press CTRL-C
=> tsp.exe does not exit and the only way to get out of this is to kill the tsp process

### 2. Process Close, Logoff and Shutdown system events

There are DVB devices where the driver causes a bluescreen when an active receive operation is not properly shut down.
That means: killing the tsp process == BSOD

When a user session is closed (by logoff, system poweroff or reboot), Windows sends the corresponding events (CTRL_CLOSE_EVENT, CTRL_LOGOFF_EVENT, CTRL_SHUTDOWN_EVENT) to all processes. Those that haven't shut down gracefully after 5 seconds are getting killed - which this PR prevents from happening.

### 3. Allow ending the process via keyboard input

When you start tsp.exe from another process rather than manually from the command line, there is no way to stop the tsp process gracefully. Unfortunately it's practically impossible on Windows, to send a CTRL-C signal to a single child-process. I had extensively researched this a year ago and it's simply a hard (and sad) fact. Remaining workarounds are coming with an unacceptable set of drawbacks (hence I'm saying 'practically impossible').
I can provide more details on the subject in case anybody would be interested.

To provide an easy way for allowing a graceful shutdown in those cases, this PR adds reading of key stroke input for Windows and when a 'q' or 'Q' is entered, operations are shut down in the same way as with a CTRL-C signal.

This should not interfere with command lines where multiple processes are piped together, because the `kbhit()` function will return zero (0) in those cases. The input key reading is mostly adopted from ffmpeg which is capable to do both of these things as well.

Having a console interface would open up a range of other nice use cases as it provides a simple way of interaction, no matter whether it's used interactively from a console or from a parent process. For example, it could be used in a way that you can press certain keys to request printing of certain statistics while running, or retrieving the current signal strength and quality values from a running dvb input. And of course - live manipulation of certain parameters.

But for this PR, it's just about having a simple way to initiate a graceful shutdown.





