### PR TITLE
Adjust DEFAULT_SINK_QUEUE_SIZE

### DIFF
--- a/src/libtsduck/dtv/tsTuner.h
+++ b/src/libtsduck/dtv/tsTuner.h
@@ -317,7 +317,7 @@ namespace ts {
         //! Default max number of queued media samples (Windows-specific).
         //! @see setSinkQueueSize().
         //!
-        static constexpr size_t DEFAULT_SINK_QUEUE_SIZE = 1000;  // media samples
+        static constexpr size_t DEFAULT_SINK_QUEUE_SIZE = 12;  // media samples
 
         //!
         //! Set the max number of queued media samples (Windows-specific).


### PR DESCRIPTION
Now that we know that the allocator provides a pool of only 24 media samples, we should adapt this to avoid the upstream filters from running out of available samples.