### PR TITLE
Restore Linux tuner status output

### DIFF
--- a/src/libtsduck/dtv/linux/tsTunerGuts.cpp
+++ b/src/libtsduck/dtv/linux/tsTunerGuts.cpp
@@ -1770,6 +1770,12 @@ std::ostream& ts::Tuner::displayStatus(std::ostream& strm, const ts::UString& ma
     ModulationArgs params;
     getCurrentTuning(params, false, report);
 
+    // Display current information
+    DisplayFlags(strm, margin, u"Status", uint32_t(status), enum_fe_status);
+    strm << std::endl;
+    strm << margin << "Device Path:      " << _device_path << std::endl;
+    //strm << margin << "Device Serial:    " << _device_serial << std::endl;
+    
     // Display delivery system.
     DeliverySystem delsys = params.delivery_system.value(DS_UNDEFINED);
     if (delsys == DS_UNDEFINED) {


### PR DESCRIPTION
I think you removed a bit too much here recently. You are querying the status but not printing it any longer.
For device path and serial, I don't remember exactly whether you had it before or whether it was my own modification..
