### PR TITLE
tsscan: Display modulation parameters for ISDB-T broadcasts.

### DIFF
--- a/src/libtsduck/dtv/tsModulationArgs.cpp
+++ b/src/libtsduck/dtv/tsModulationArgs.cpp
@@ -1030,6 +1030,10 @@ void ts::ModulationArgs::display(std::ostream& strm, const ts::UString& margin, 
         strm << margin << "Modulation: " << ModulationEnum.name(modulation.value()) << std::endl;
     }
 
+    if (!delivery_system.set()) {
+        return;
+    }
+
     switch (TunerTypeOf(delivery_system.value())) {
         case TT_DVB_C: {
             if (symbol_rate.set() && symbol_rate != 0) {

--- a/src/libtsduck/dtv/tsModulationArgs.cpp
+++ b/src/libtsduck/dtv/tsModulationArgs.cpp
@@ -1151,10 +1151,10 @@ void ts::ModulationArgs::display(std::ostream& strm, const ts::UString& margin, 
             if (layer_a_modulation.set() && layer_a_modulation != QAM_AUTO) {
                 strm << margin << "Layers A modulation: " << InnerFECEnum.name(layer_a_modulation.value()) << std::endl;
             }
-            if (layer_a_segment_count.set()) {
+            if (layer_a_segment_count.set() && layer_a_segment_count.value() <= 13) {
                 strm << margin << "Layers A segment count: " << layer_a_segment_count.value() << std::endl;
             }
-            if (layer_a_time_interleaving.set()) {
+            if (layer_a_time_interleaving.set() && layer_a_time_interleaving != 255) {
                 strm << margin << "Layers A time interleaving: " << layer_a_time_interleaving.value() << std::endl;
             }
             if (layer_b_fec.set() && layer_b_fec != FEC_AUTO) {
@@ -1163,10 +1163,10 @@ void ts::ModulationArgs::display(std::ostream& strm, const ts::UString& margin, 
             if (layer_b_modulation.set() && layer_b_modulation != QAM_AUTO) {
                 strm << margin << "Layers B modulation: " << InnerFECEnum.name(layer_b_modulation.value()) << std::endl;
             }
-            if (layer_b_segment_count.set()) {
+            if (layer_b_segment_count.set() && layer_b_segment_count.value() <= 13) {
                 strm << margin << "Layers B segment count: " << layer_b_segment_count.value() << std::endl;
             }
-            if (layer_b_time_interleaving.set()) {
+            if (layer_b_time_interleaving.set() && layer_b_time_interleaving != 255) {
                 strm << margin << "Layers B time interleaving: " << layer_b_time_interleaving.value() << std::endl;
             }
             if (layer_c_fec.set() && layer_c_fec != FEC_AUTO) {
@@ -1175,10 +1175,10 @@ void ts::ModulationArgs::display(std::ostream& strm, const ts::UString& margin, 
             if (layer_c_modulation.set() && layer_c_modulation != QAM_AUTO) {
                 strm << margin << "Layers C modulation: " << InnerFECEnum.name(layer_c_modulation.value()) << std::endl;
             }
-            if (layer_c_segment_count.set()) {
+            if (layer_c_segment_count.set() && layer_c_segment_count.value() <= 13) {
                 strm << margin << "Layers C segment count: " << layer_c_segment_count.value() << std::endl;
             }
-            if (layer_c_time_interleaving.set()) {
+            if (layer_c_time_interleaving.set() && layer_c_time_interleaving != 255) {
                 strm << margin << "Layers C time interleaving: " << layer_c_time_interleaving.value() << std::endl;
             }
             break;

--- a/src/libtsduck/dtv/tsModulationArgs.cpp
+++ b/src/libtsduck/dtv/tsModulationArgs.cpp
@@ -1146,40 +1146,40 @@ void ts::ModulationArgs::display(std::ostream& strm, const ts::UString& margin, 
                 strm << margin << "Partial reception: " << UString::OnOff(isdbt_partial_reception.value()) << std::endl;
             }
             if (layer_a_fec.set() && layer_a_fec != FEC_AUTO) {
-                strm << margin << "Layers A FEC: " << InnerFECEnum.name(layer_a_fec.value()) << std::endl;
+                strm << margin << "Layer A FEC: " << InnerFECEnum.name(layer_a_fec.value()) << std::endl;
             }
             if (layer_a_modulation.set() && layer_a_modulation != QAM_AUTO) {
-                strm << margin << "Layers A modulation: " << InnerFECEnum.name(layer_a_modulation.value()) << std::endl;
+                strm << margin << "Layer A modulation: " << InnerFECEnum.name(layer_a_modulation.value()) << std::endl;
             }
             if (layer_a_segment_count.set() && layer_a_segment_count.value() <= 13) {
-                strm << margin << "Layers A segment count: " << layer_a_segment_count.value() << std::endl;
+                strm << margin << "Layer A segment count: " << layer_a_segment_count.value() << std::endl;
             }
             if (layer_a_time_interleaving.set() && layer_a_time_interleaving != 255) {
-                strm << margin << "Layers A time interleaving: " << layer_a_time_interleaving.value() << std::endl;
+                strm << margin << "Layer A time interleaving: " << layer_a_time_interleaving.value() << std::endl;
             }
             if (layer_b_fec.set() && layer_b_fec != FEC_AUTO) {
-                strm << margin << "Layers B FEC: " << InnerFECEnum.name(layer_b_fec.value()) << std::endl;
+                strm << margin << "Layer B FEC: " << InnerFECEnum.name(layer_b_fec.value()) << std::endl;
             }
             if (layer_b_modulation.set() && layer_b_modulation != QAM_AUTO) {
-                strm << margin << "Layers B modulation: " << InnerFECEnum.name(layer_b_modulation.value()) << std::endl;
+                strm << margin << "Layer B modulation: " << InnerFECEnum.name(layer_b_modulation.value()) << std::endl;
             }
             if (layer_b_segment_count.set() && layer_b_segment_count.value() <= 13) {
-                strm << margin << "Layers B segment count: " << layer_b_segment_count.value() << std::endl;
+                strm << margin << "Layer B segment count: " << layer_b_segment_count.value() << std::endl;
             }
             if (layer_b_time_interleaving.set() && layer_b_time_interleaving != 255) {
-                strm << margin << "Layers B time interleaving: " << layer_b_time_interleaving.value() << std::endl;
+                strm << margin << "Layer B time interleaving: " << layer_b_time_interleaving.value() << std::endl;
             }
             if (layer_c_fec.set() && layer_c_fec != FEC_AUTO) {
-                strm << margin << "Layers C FEC: " << InnerFECEnum.name(layer_c_fec.value()) << std::endl;
+                strm << margin << "Layer C FEC: " << InnerFECEnum.name(layer_c_fec.value()) << std::endl;
             }
             if (layer_c_modulation.set() && layer_c_modulation != QAM_AUTO) {
-                strm << margin << "Layers C modulation: " << InnerFECEnum.name(layer_c_modulation.value()) << std::endl;
+                strm << margin << "Layer C modulation: " << InnerFECEnum.name(layer_c_modulation.value()) << std::endl;
             }
             if (layer_c_segment_count.set() && layer_c_segment_count.value() <= 13) {
-                strm << margin << "Layers C segment count: " << layer_c_segment_count.value() << std::endl;
+                strm << margin << "Layer C segment count: " << layer_c_segment_count.value() << std::endl;
             }
             if (layer_c_time_interleaving.set() && layer_c_time_interleaving != 255) {
-                strm << margin << "Layers C time interleaving: " << layer_c_time_interleaving.value() << std::endl;
+                strm << margin << "Layer C time interleaving: " << layer_c_time_interleaving.value() << std::endl;
             }
             break;
         }

--- a/src/libtsduck/dtv/tsModulationArgs.cpp
+++ b/src/libtsduck/dtv/tsModulationArgs.cpp
@@ -1149,7 +1149,7 @@ void ts::ModulationArgs::display(std::ostream& strm, const ts::UString& margin, 
                 strm << margin << "Layer A FEC: " << InnerFECEnum.name(layer_a_fec.value()) << std::endl;
             }
             if (layer_a_modulation.set() && layer_a_modulation != QAM_AUTO) {
-                strm << margin << "Layer A modulation: " << InnerFECEnum.name(layer_a_modulation.value()) << std::endl;
+                strm << margin << "Layer A modulation: " << ModulationEnum.name(layer_a_modulation.value()) << std::endl;
             }
             if (layer_a_segment_count.set() && layer_a_segment_count.value() <= 13) {
                 strm << margin << "Layer A segment count: " << layer_a_segment_count.value() << std::endl;
@@ -1161,7 +1161,7 @@ void ts::ModulationArgs::display(std::ostream& strm, const ts::UString& margin, 
                 strm << margin << "Layer B FEC: " << InnerFECEnum.name(layer_b_fec.value()) << std::endl;
             }
             if (layer_b_modulation.set() && layer_b_modulation != QAM_AUTO) {
-                strm << margin << "Layer B modulation: " << InnerFECEnum.name(layer_b_modulation.value()) << std::endl;
+                strm << margin << "Layer B modulation: " << ModulationEnum.name(layer_b_modulation.value()) << std::endl;
             }
             if (layer_b_segment_count.set() && layer_b_segment_count.value() <= 13) {
                 strm << margin << "Layer B segment count: " << layer_b_segment_count.value() << std::endl;
@@ -1173,7 +1173,7 @@ void ts::ModulationArgs::display(std::ostream& strm, const ts::UString& margin, 
                 strm << margin << "Layer C FEC: " << InnerFECEnum.name(layer_c_fec.value()) << std::endl;
             }
             if (layer_c_modulation.set() && layer_c_modulation != QAM_AUTO) {
-                strm << margin << "Layer C modulation: " << InnerFECEnum.name(layer_c_modulation.value()) << std::endl;
+                strm << margin << "Layer C modulation: " << ModulationEnum.name(layer_c_modulation.value()) << std::endl;
             }
             if (layer_c_segment_count.set() && layer_c_segment_count.value() <= 13) {
                 strm << margin << "Layer C segment count: " << layer_c_segment_count.value() << std::endl;

--- a/src/libtsduck/dtv/tsTSScanner.cpp
+++ b/src/libtsduck/dtv/tsTSScanner.cpp
@@ -68,11 +68,6 @@ ts::TSScanner::TSScanner(DuckContext& duck, Tuner& tuner, MilliSecond timeout, b
         return;
     }
 
-    // Get current tuning parameters.
-    if (!tuner.getCurrentTuning(_tparams, true, _report)) {
-        _tparams.reset();
-    }
-
     // Deadline for table collection
     const Time deadline(timeout == Infinite ? Time::Apocalypse : Time::CurrentUTC() + timeout);
 
@@ -89,6 +84,12 @@ ts::TSScanner::TSScanner(DuckContext& duck, Tuner& tuner, MilliSecond timeout, b
         for (size_t n = 0; !_completed && n < pcount; ++n) {
             _demux.feedPacket(buffer[n]);
         }
+    }
+
+    // Get current tuning parameters before finishing.
+    // Some tuners may take a while to update their internal status.
+    if (!tuner.getCurrentTuning(_tparams, true, _report)) {
+        _tparams.reset();
     }
 
     // Stop packet acquisition

--- a/src/tstools/tsscan.cpp
+++ b/src/tstools/tsscan.cpp
@@ -548,9 +548,8 @@ void ScanContext::scanTS(std::ostream& strm, const ts::UString& margin, ts::Modu
     // Use "PAT only" when we do not need the services or channels file.
     ts::TSScanner info(_opt.duck, _tuner, _opt.psi_timeout, !get_services && _opt.channel_file.empty());
 
-    if (!tparams.hasModulationArgs()) {
-        info.getTunerParameters(tparams);
-    }
+    // Get tuning parameters again, as TSScanner waits for a lock.
+    info.getTunerParameters(tparams);
 
     ts::SafePtr<ts::PAT> pat;
     ts::SafePtr<ts::SDT> sdt;


### PR DESCRIPTION
#### Related issue (if any):
The issue related with incorrect transmission parameters with some ISDB-T tuners (last posts on #24)

#### Affected components:
`tsscan` and libtsduck/dtv/tsModulationArgs.cpp

#### Brief description of the proposed changes:
This series of commits provide a fix for the invalid modulation parameters with some ISDB-T tuners.
Basically this solution:

- Uses TSScanner to retrieve the modulation parameters that should be displayed.
- Inside TSScanner, do the tuning parameters query as late as possible to give the device some time to update its internal status.
- Corrects the enumeration used for displaying per-layer constellation types.
- Checks the validity of some parameters before showing them.
- Fixes some typos with the displayed data.