### PR TITLE
Fix bad parameters issue on srt_accept()

### DIFF
--- a/src/libtsduck/base/network/tsSRTSocket.cpp
+++ b/src/libtsduck/base/network/tsSRTSocket.cpp
@@ -691,8 +691,8 @@ bool ts::SRTSocket::Guts::setSockOptPost(ts::Report& report)
 
 int ts::SRTSocket::Guts::srtListen(const ts::SocketAddress& addr, ts::Report& report)
 {
-    int ret, reuse = 1, peer_addr_len;
     ::sockaddr sock_addr, peer_addr;
+    int ret, reuse = 1, peer_addr_len = sizeof(peer_addr);
     addr.copy(sock_addr);
 
     ret = setSockOpt(SRTO_REUSEADDR, "SRTO_REUSEADDR", &reuse, sizeof(reuse), report);

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 2294
+#define TS_COMMIT 2296


### PR DESCRIPTION
A missing initialization on `int *addrlen` of srt_accept() cause a bad
paremeters error (SRT_EINVPARAM).

This error seems to have no consequences until libsrt >= 1.4.2

See: https://github.com/tsduck/tsduck/issues/738
See: https://github.com/Haivision/srt/blob/master/docs/API-functions.md#srt_accept

<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->

#### Brief description of the proposed changes:
