### PR TITLE
Update Makefile.tsduck

### DIFF
--- a/Makefile.tsduck
+++ b/Makefile.tsduck
@@ -194,5 +194,7 @@ endif
 
 # Make sure that full paths of source files never appear in binaries.
 ifneq ($(CC_FILE_PREFIX_MAP),)
-    CXXFLAGS += -ffile-prefix-map=$(SRCROOT)/=
+    ifeq ($(DEBUG),)
+        CXXFLAGS += -ffile-prefix-map=$(SRCROOT)/=
+    endif    
 endif


### PR DESCRIPTION
Retain full paths of source files in binaries for the ease of debugging

<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->

#### Brief description of the proposed changes:
Relative source file paths in debug symbol causes a lot of troubles to use debugger. Suggest to preserve the absolute path in debug mode.
