### PR TITLE
Support monitoring preroll time for time signal command

### DIFF
--- a/src/libtsduck/dtv/descriptors/tsSpliceSegmentationDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/tsSpliceSegmentationDescriptor.cpp
@@ -110,6 +110,60 @@ bool ts::SpliceSegmentationDescriptor::deliveryNotRestricted() const
     return web_delivery_allowed && no_regional_blackout && archive_allowed && device_restrictions == 3;
 }
 
+//----------------------------------------------------------------------------
+// Check if the signal is an out.
+//----------------------------------------------------------------------------
+
+bool ts::SpliceSegmentationDescriptor::isOut() const
+{
+    switch (segmentation_type_id) {
+    case 0x10: //Program Start
+    case 0x14: //Program Resumption
+    case 0x17: //Program Overlap Start
+    case 0x19: //Program Start In Progress
+    case 0x20: //Chapter Start
+    case 0x22: //Break Start
+    case 0x30: //Provider Advertisement Start
+    case 0x32: //Distributor Advertisement Start
+    case 0x34: //Provider Placement Opportunity Start
+    case 0x36: //Distributor Placement Opportunity Start
+    case 0x40: //Unscheduled Event Start
+    case 0x50: //Network Start
+        return true;
+    default:
+        return false;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Check if the signal is an in.
+//----------------------------------------------------------------------------
+
+bool ts::SpliceSegmentationDescriptor::isIn() const
+{
+    switch (segmentation_type_id) {
+    case 0x11: //Program End
+    case 0x12: //Program Early Termination
+    case 0x13: //Program Breakaway
+    case 0x15: //Program Runover Planned
+    case 0x16: //Program Runover Unplanned
+    case 0x18: //Program Blackout Override
+    case 0x21: //Chapter End
+    case 0x23: //Break End
+    case 0x31: //Provider Advertisement End
+    case 0x33: //Distributor Advertisement End
+    case 0x35: //Provider Placement Opportunity End
+    case 0x37: //Distributor Placement Opportunity End
+    case 0x41: //Unscheduled Event End
+    case 0x51: //Network End
+        return true;
+    default:
+        return false;
+    }
+}
+
+
 
 //----------------------------------------------------------------------------
 // Serialization

--- a/src/libtsduck/dtv/descriptors/tsSpliceSegmentationDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/tsSpliceSegmentationDescriptor.h
@@ -91,6 +91,18 @@ namespace ts {
         //!
         bool deliveryNotRestricted() const;
 
+        //!
+        //! Check if the signal is an in.
+        //! @return Value based on the segmentation_type_id.
+        //!
+        bool isIn() const;
+
+        //!
+        //! Check if the signal is an out.
+        //! @return Value based on the segmentation_type_id.
+        //!
+        bool isOut() const;
+
         // Inherited methods
         DeclareDisplayDescriptor();
 

--- a/src/libtsduck/dtv/tables/tsSpliceInformationTable.cpp
+++ b/src/libtsduck/dtv/tables/tsSpliceInformationTable.cpp
@@ -127,9 +127,19 @@ void ts::SpliceInformationTable::clearContent()
 
 void ts::SpliceInformationTable::adjustPTS()
 {
-    // Only splice_insert() commands need adjustment.
+    // Ignore null or invalid adjustment.
+    if (pts_adjustment == 0 || pts_adjustment > PTS_DTS_MASK) {
+        return;
+    }
+
+    // Only splice_insert() and time_signal() commands need adjustment.
     if (splice_command_type == SPLICE_INSERT) {
         splice_insert.adjustPTS(pts_adjustment);
+    } else if (splice_command_type == SPLICE_TIME_SIGNAL) {
+        // Adjust time signal time.
+        if (time_signal.set() && time_signal.value() <= PTS_DTS_MASK) {
+            time_signal = (time_signal.value() + pts_adjustment) & PTS_DTS_MASK;
+        }
     }
 
     // Adjustment applied, don't do it again.

--- a/src/tsplugins/tsplugin_splicemonitor.cpp
+++ b/src/tsplugins/tsplugin_splicemonitor.cpp
@@ -38,6 +38,7 @@
 #include "tsSectionDemux.h"
 #include "tsSignalizationDemux.h"
 #include "tsSpliceInformationTable.h"
+#include "tsSpliceSegmentationDescriptor.h"
 #include "tsForkPipe.h"
 TSDUCK_SOURCE;
 
@@ -399,15 +400,16 @@ void ts::SpliceMonitorPlugin::display(const UString& line)
 void ts::SpliceMonitorPlugin::handleTable(SectionDemux& demux, const BinaryTable& table)
 {
     // Convert to a Splice Information Table.
-    const SpliceInformationTable sit(duck, table);
+    SpliceInformationTable sit(duck, table);
     if (!sit.isValid()) {
         // Was not a Splice Information Table.
         return;
     }
     const bool is_insert = sit.splice_command_type == SPLICE_INSERT;
+    const bool is_time_signal = sit.splice_command_type == SPLICE_TIME_SIGNAL;
 
     // Give up now if there is nothing to display.
-    if (!is_insert && !_all_commands) {
+    if (!is_insert && !is_time_signal && !_all_commands) {
         return;
     }
 
@@ -415,9 +417,61 @@ void ts::SpliceMonitorPlugin::handleTable(SectionDemux& demux, const BinaryTable
     const PID spid = table.sourcePID();
     SpliceContext& ctx(_splice_contexts[spid]);
 
-    if (!is_insert) {
+    if (!is_insert && !is_time_signal) {
         // Not an insert command, just display it without initial message.
         _display << std::endl;
+    }
+    else if(is_time_signal) {
+        sit.adjustPTS();
+        for (size_t di = 0; di < sit.descs.count(); ++di) {
+            if (sit.descs[di]->tag() == DID_SPLICE_SEGMENT) {
+                // SCTE 35 SIT segmentation_descriptor.
+                const SpliceSegmentationDescriptor ssd(duck, *sit.descs[di]);
+                const uint64_t event_pts = sit.time_signal.value();
+                if (!ssd.isValid()) {
+                    continue;
+                }
+                if (ssd.segmentation_event_cancel) {
+                    display(message(spid, ssd.segmentation_event_id, u"canceled"));
+                } else if (ssd.isIn() || ssd.isOut()) {
+                    SpliceEvent& evt(ctx.splice_events[ssd.segmentation_event_id]);
+                    // This is a planned time signal command. Is this a repetition or new event?
+                    if (ssd.segmentation_event_id == evt.event_id && event_pts == evt.event_pts && ssd.isOut() == evt.event_out) {
+                        // Repetition of a previous event.
+                        evt.event_count++;
+                    }
+                    else {
+                        // First command about a new event.
+                        evt.event_id = ssd.segmentation_event_id;
+                        evt.event_pts = event_pts;
+                        evt.event_out = ssd.isOut();
+                        evt.event_count = 1;
+                        evt.first_cmd_packet = tsp->pluginPackets();
+                    }
+                    // Format time to event.
+                    UString time;
+                    if (ctx.last_pts != INVALID_PTS) {
+                        // Compute "current" PTS. We use the latest PTS found and adjust it by the distance to its packet.
+                        uint64_t current_pts = ctx.last_pts;
+                        if (!_no_adjustment) {
+                            const PacketCounter distance = tsp->pluginPackets() - ctx.last_pts_packet;
+                            const BitRate bitrate = tsp->bitrate();
+                            if (bitrate != 0 && distance != 0)
+                            {
+                                current_pts += ((distance * PKT_SIZE_BITS * SYSTEM_CLOCK_SUBFREQ) / bitrate).toInt();
+                            }
+                        }
+                        if (current_pts > evt.event_pts) {
+                            time.format(u", event is in the past by %'d ms", {PTSToMilliSecond(current_pts - evt.event_pts)});
+                        }
+                        else {
+                            time.format(u", time to event: %'d ms", {PTSToMilliSecond(evt.event_pts - current_pts)});
+                        }
+                    }
+                    display(message(spid, ssd.segmentation_event_id, u"occurrence #%d%s", {evt.event_count, time}));
+                }
+            }
+        }
     }
     else {
         // Get a copy of the splice insert command and adjust all PTS to actual time value.


### PR DESCRIPTION
<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->
.tsp -I {input} -P splicemonitor -O drop


#### Brief description of the proposed changes:
Add support to monitor preroll time of SCTE35 time signal command.