### PR TITLE
Detect Centos Stream as minor version 99.

### DIFF
--- a/build/install-prerequisites.sh
+++ b/build/install-prerequisites.sh
@@ -181,7 +181,7 @@ elif [[ -f /etc/fedora-release ]]; then
 elif [[ -f /etc/redhat-release ]]; then
 
     # Red Hat or CentOS
-    EL=$(grep " release " /etc/redhat-release 2>/dev/null | sed -e 's/^.* release \([0-9]*\.[0-9]*\).*$/\1/')
+    EL=$(grep " release " /etc/redhat-release 2>/dev/null | sed -e 's/.*/&.99/' | sed -e 's/^.* release \([0-9]*\.[0-9]*\).*$/\1/')
     EL=$(( ${EL/.*/} * 100 + ${EL/*./} ))
     pkglist="gcc-c++ dos2unix curl tar zip doxygen graphviz pcsc-lite pcsc-lite-devel libcurl libcurl-devel rpmdevtools python3 java-latest-openjdk-devel"
     if $STATIC; then


### PR DESCRIPTION
E.G. centos Stream 8 will be 899 All other releases contain proper minor revisions and thus igore the trailing .99

<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->

#### Brief description of the proposed changes:
