### PR TITLE
fixes to pkgconfig file tsduck.pc

### DIFF
--- a/src/libtsduck/config/Makefile
+++ b/src/libtsduck/config/Makefile
@@ -74,7 +74,7 @@ install-devel:
 	    $(if $(NOSRT),-e 's|srt||g',) \
 	    $(if $(NORIST),-e 's|librist||g',) \
 	    $(if $(NOPCSC),-e 's|libpcsclite||g',) \
-	    $(if $(NOCURL),-e 's|libcurl||d',) \
+	    $(if $(NOCURL),-e 's|libcurl||g',) \
 	    -e 's|:[ ,]*|: |' -e 's|,[ ,]*|, |' -e 's|[ ,]*$$||' \
 	    tsduck.pc >$(SYSROOT)$(SYSPREFIX)/share/pkgconfig/tsduck.pc
 	chmod 644 $(SYSROOT)$(SYSPREFIX)/share/pkgconfig/tsduck.pc

--- a/src/libtsduck/config/Makefile
+++ b/src/libtsduck/config/Makefile
@@ -74,6 +74,7 @@ install-devel:
 	    $(if $(NOSRT),-e 's|srt||g',) \
 	    $(if $(NORIST),-e 's|librist||g',) \
 	    $(if $(NOPCSC),-e 's|libpcsclite||g',) \
+	    $(if $(NOEDITLINE),-e 's|libedit||g',) \
 	    $(if $(NOCURL),-e 's|libcurl||g',) \
 	    -e 's|:[ ,]*|: |' -e 's|,[ ,]*|, |' -e 's|[ ,]*$$||' \
 	    tsduck.pc >$(SYSROOT)$(SYSPREFIX)/share/pkgconfig/tsduck.pc


### PR DESCRIPTION
#### Related issue (if any):
#902
#903
#### Affected components:
tsduck.pc
#### Brief description of the proposed changes:
There are several minor issues with tsduck.pc and its dependencies, when disabling certain features. One (#902) in its creation, one (#903) in its result.