### PR TITLE
Input modulation improvements

### DIFF
--- a/src/libtsduck/dektec/tsDektecOutputPlugin.h
+++ b/src/libtsduck/dektec/tsDektecOutputPlugin.h
@@ -36,6 +36,7 @@
 #if !defined(TS_NO_DTAPI) || defined(DOXYGEN)
 
 #include "tsOutputPlugin.h"
+#include "tsBitrateDifferenceDVBT.h"
 
 namespace ts {
     //!
@@ -89,6 +90,9 @@ namespace ts {
         // Set preload FIFO size based on a delay, if requested, in ms. Returns true if preload FIFO size is altered,
         // false otherwise.
         bool setPreloadFIFOSizeBasedOnDelay();
+
+        // Checks whether calculated parameters for dvb-t do not override user specified params
+        bool ParamsMatchUserOverrides(const ts::BitrateDifferenceDVBT& params);
     };
 }
 


### PR DESCRIPTION
Hi,
There are 2 patches here, first:
I personally need to stream DVB-T .ts files on bandwidth 8MHz, but wanted to have the rest parameters calculated with "input modulation". I went a step further, so that the user can specify any combination of the four parameters used for bitrate evaluation and the algorithm will choose the best one matching user's needs.

The second patch only touches my recent addition of "input-modulation" for DVB-T2 to make it slightly faster at the cost of precision. My initial implementation turned out needlessly too aggressive for everyday use.