### PR TITLE
Allow Headers To Be Used From C++20 Code

### DIFF
--- a/src/libtsduck/base/algo/tsMessageQueueTemplate.h
+++ b/src/libtsduck/base/algo/tsMessageQueueTemplate.h
@@ -46,7 +46,7 @@ ts::MessageQueue<MSG, MUTEX>::MessageQueue(size_t maxMessages) :
 }
 
 template <typename MSG, class MUTEX>
-ts::MessageQueue<MSG, MUTEX>::~MessageQueue<MSG, MUTEX>()
+ts::MessageQueue<MSG, MUTEX>::~MessageQueue()
 {
 }
 

--- a/src/libtsduck/base/report/tsReportFileTemplate.h
+++ b/src/libtsduck/base/report/tsReportFileTemplate.h
@@ -71,7 +71,7 @@ ts::ReportFile<MUTEX>::ReportFile(std::ostream& stream, int max_severity) :
 //----------------------------------------------------------------------------
 
 template <class MUTEX>
-ts::ReportFile<MUTEX>::~ReportFile<MUTEX>()
+ts::ReportFile<MUTEX>::~ReportFile()
 {
     GuardMutex lock(_mutex);
 

--- a/src/libtsduck/base/system/tsResidentBufferTemplate.h
+++ b/src/libtsduck/base/system/tsResidentBufferTemplate.h
@@ -126,7 +126,7 @@ ts::ResidentBuffer<T>::ResidentBuffer(size_t elem_count) :
 //----------------------------------------------------------------------------
 
 template <typename T>
-ts::ResidentBuffer<T>::~ResidentBuffer<T>()
+ts::ResidentBuffer<T>::~ResidentBuffer()
 {
     // Unlock from physical memory
     if (_is_locked) {

--- a/src/libtsduck/base/types/tsFloatingPoint.h
+++ b/src/libtsduck/base/types/tsFloatingPoint.h
@@ -250,8 +250,10 @@ inline ts::FloatingPoint<FLOAT_T,PREC> operator*(NUM_T x1, const ts::FloatingPoi
 template<typename NUM_T, typename FLOAT_T, const size_t PREC, typename std::enable_if<std::is_arithmetic<NUM_T>::value && std::is_floating_point<FLOAT_T>::value, int>::type = 0>
 inline ts::FloatingPoint<FLOAT_T,PREC> operator/(NUM_T x1, const ts::FloatingPoint<FLOAT_T,PREC>& x2) { return ts::FloatingPoint<FLOAT_T,PREC>(x1) / x2; }
 
+// This one explicitly calls the operator== method because without it, you get an error when built with C++20
+// error: in C++20 this comparison calls the current function recursively with reversed arguments
 template<typename NUM_T, typename FLOAT_T, const size_t PREC, typename std::enable_if<std::is_arithmetic<NUM_T>::value && std::is_floating_point<FLOAT_T>::value, int>::type = 0>
-inline bool operator==(NUM_T x1, const ts::FloatingPoint<FLOAT_T,PREC>& x2) { return x2 == x1; }
+inline bool operator==(NUM_T x1, const ts::FloatingPoint<FLOAT_T,PREC>& x2) { return x2.operator==(x1); }
 
 template<typename NUM_T, typename FLOAT_T, const size_t PREC, typename std::enable_if<std::is_arithmetic<NUM_T>::value && std::is_floating_point<FLOAT_T>::value, int>::type = 0>
 inline bool operator!=(NUM_T x1, const ts::FloatingPoint<FLOAT_T,PREC>& x2) { return x2 != x1; }

--- a/src/libtsduck/base/types/tsSafePtrTemplate.h
+++ b/src/libtsduck/base/types/tsSafePtrTemplate.h
@@ -35,7 +35,7 @@
 //----------------------------------------------------------------------------
 
 template <typename T, class MUTEX>
-ts::SafePtr<T,MUTEX>::~SafePtr<T,MUTEX>()
+ts::SafePtr<T,MUTEX>::~SafePtr()
 {
     if (_shared != nullptr && _shared->detach()) {
         _shared = nullptr;

--- a/src/libtsduck/base/types/tsVariableTemplate.h
+++ b/src/libtsduck/base/types/tsVariableTemplate.h
@@ -54,7 +54,7 @@ ts::Variable<T>::Variable(Variable<T>&& other) :
 }
 
 template <typename T>
-ts::Variable<T>::~Variable<T>()
+ts::Variable<T>::~Variable()
 {
     clear();
 }

--- a/src/libtsduck/crypto/tsCipherChainingTemplate.h
+++ b/src/libtsduck/crypto/tsCipherChainingTemplate.h
@@ -41,7 +41,7 @@ ts::CipherChainingTemplate<CIPHER>::CipherChainingTemplate(size_t iv_min_blocks,
 }
 
 template <class CIPHER>
-ts::CipherChainingTemplate<CIPHER>::~CipherChainingTemplate<CIPHER>()
+ts::CipherChainingTemplate<CIPHER>::~CipherChainingTemplate()
 {
     if (algo != nullptr) {
         delete algo;


### PR DESCRIPTION
When using TSDuck from a C++20 application, the headers throw various
errors. This commit tidies them up.

The library itself still does not build cleanly as C++20 (biggest problem is the
initialisation of the const TSPacket instances in tsTSPacket.c) however this is enough for 

<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
Various types in libtsduck

#### Brief description of the proposed changes:
Most changes are removing the template arguments from destructors. These redundant arguments cause warnings (which frequently become errors) when building a C++20 target

There's also a change to `operator==(NUM_T x1, const ts::FloatingPoint<FLOAT_T,PREC>& x2)`  because C++20 seems to reorder operator arguments, which causes the original implementation of this to become in infinite loop (again, this caused a compiler warning which became an error) - the fix is to explicitly call the intended operator, preventing the infinite loop