### PR TITLE
Reuse T2-MI packet size

### DIFF
--- a/src/libtsduck/dtv/t2mi/tsT2MIDemux.cpp
+++ b/src/libtsduck/dtv/t2mi/tsT2MIDemux.cpp
@@ -225,7 +225,7 @@ void ts::T2MIDemux::processT2MI(PID pid, PIDContext& pc)
             }
 
             // Point to next T2-MI packet.
-            start += T2MI_HEADER_SIZE + payload_bytes + SECTION_CRC32_SIZE;
+            start += packet_size;
         }
 
         // Remove processed T2-MI packets.


### PR DESCRIPTION
#### Affected components:
T2-MI plugin (`t2mi`)

#### Brief description of the proposed changes:
Tiny optimization, reusing the previously determined T2-MI packet size.