### PR TITLE
Updates to AVS3 and VVC codecs

### DIFF
--- a/src/libtsduck/dtv/descriptors/tsAVS3VideoDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/tsAVS3VideoDescriptor.h
@@ -36,6 +36,8 @@
 #include "tsAbstractDescriptor.h"
 #include "tsVariable.h"
 
+#include <vector>
+
 namespace ts {
     //!
     //! Representation of an AVS3_video_descriptor.
@@ -82,6 +84,15 @@ namespace ts {
         static UString AVS3FrameRate(uint16_t fr);
         static UString AVS3SamplePrecision(uint16_t sp);
         static UString Avs3ChromaFormat(uint16_t cf);
+
+        // T/AI 109.2 Table B.1
+        std::vector<uint8_t> valid_profile_ids {0x20, 0x22, 0x30, 0x32};
+
+        // T/AI 109.2 Table B.2
+        std::vector<uint8_t> valid_level_ids {0x10, 0x12, 0x14, 0x20, 0x22,
+                                              0x40, 0x42, 0x41, 0x43, 0x44, 0x46, 0x45, 0x47, 0x48, 0x4a, 0x49, 0x4b,
+                                              0x50, 0x52, 0x51, 0x53, 0x54, 0x56, 0x55, 0x57, 0x58, 0x5a, 0x59, 0x5b, 
+                                              0x60, 0x62, 0x61, 0x63, 0x64, 0x66, 0x65, 0x67, 0x68, 0x6a, 0x69, 0x6b};
 
     protected:
         // Inherited methods

--- a/src/libtsduck/dtv/descriptors/tsDVBVVCSubpicturesDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/tsDVBVVCSubpicturesDescriptor.cpp
@@ -36,7 +36,7 @@
 #include "tsDuckContext.h"
 #include "tsxmlElement.h"
 
-#define MY_XML_NAME u"dvb_vvc_subpictures_descriptor"
+#define MY_XML_NAME u"vvc_subpictures_descriptor"
 #define MY_XML_NAME_LEGACY u"VVC_subpictures_descriptor"
 #define MY_CLASS ts::DVBVVCSubpicturesDescriptor
 #define MY_DID ts::DID_DVB_EXTENSION


### PR DESCRIPTION
AVS3 - stricter checking on values parsed from XML
VVC - use descriptor name "vvc_subpictures_descriptor" as defined in EN 300 468
