### PR TITLE
Make sure python3 is used in makefiles

### DIFF
--- a/src/libtsduck/config/Makefile
+++ b/src/libtsduck/config/Makefile
@@ -74,7 +74,7 @@ $(NAMES_DEST): $(NAMES_SRC) $(NAMES_SUBS)
 
 $(DEKTEC_DEST): $(shell $(SCRIPTSDIR)/dtapi-config.sh --header)
 	@echo '  [GEN] $(notdir $@)'; \
-	$(SCRIPTSDIR)/build-dektec-names.py $(if $<,$<,/dev/null) $@
+	$(PYTHON) $(SCRIPTSDIR)/build-dektec-names.py $(if $<,$<,/dev/null) $@
 
 # Install configuration files.
 


### PR DESCRIPTION
This fixes a regression in eb8e5425afef47b9bbc4c815f9c071194127166d and amends b5eeb6787fd2ed23908d8d173099afbc40df8a6c.

Fixes https://github.com/tsduck/tsduck/issues/1111

<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
#1111 

#### Affected components:
dectek.names

#### Brief description of the proposed changes:
Fix build with python3 and no binary named "python".