### PR TITLE
Fix svresync plugin with independent PCR pid

### DIFF
--- a/src/tsplugins/tsplugin_svresync.cpp
+++ b/src/tsplugins/tsplugin_svresync.cpp
@@ -196,6 +196,7 @@ void ts::SVResyncPlugin::handleService(uint16_t ts_id, const Service& service, c
         for (const auto& it : pmt.streams) {
             _target_pids.set(it.first);
         }
+        _target_pids.set(pmt.pcr_pid);
 
         // If the PCR PID changed, reset our PCR adjustment.
         if (pmt.pcr_pid != _target_pcr_pid) {


### PR DESCRIPTION
Add support for the edge case when the PCR is inside an independent pid. Fixes #1095.
