### PR TITLE
migrate from AdoptOpenJDK API to Adoptium

### DIFF
--- a/scripts/install-wintools/install-java.ps1
+++ b/scripts/install-wintools/install-java.ps1
@@ -52,8 +52,8 @@ Write-Output "==== Java (AdoptOpenJDK) download and installation procedure"
 
 . "$PSScriptRoot\install-common.ps1"
 
-# REST API for the latest releases of AdoptOpenJDK.
-$API = "https://api.adoptopenjdk.net/v3"
+# REST API for the latest releases of Eclipse Temurin.
+$API = "https://api.adoptium.net/v3"
 
 # Get JDK or JRE.
 if ($JRE) {


### PR DESCRIPTION
The AdoptOpenJDK API has been deprecated for some time in favour of the Eclipse Temurin API

<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->

#### Brief description of the proposed changes:
