### PR TITLE
Corrections in RIST plugins' comments

### DIFF
--- a/src/libtsduck/plugins/plugins/tsRISTInputPlugin.cpp
+++ b/src/libtsduck/plugins/plugins/tsRISTInputPlugin.cpp
@@ -44,7 +44,7 @@ bool ts::RISTInputPlugin::isRealTime()
 
 
 //----------------------------------------------------------------------------
-// Stubs in the absence of libsrt.
+// Stubs in the absence of librist.
 //----------------------------------------------------------------------------
 
 #if defined(TS_NO_RIST)

--- a/src/libtsduck/plugins/plugins/tsRISTOutputPlugin.cpp
+++ b/src/libtsduck/plugins/plugins/tsRISTOutputPlugin.cpp
@@ -44,7 +44,7 @@ bool ts::RISTOutputPlugin::isRealTime()
 
 
 //----------------------------------------------------------------------------
-// Stubs in the absence of libsrt.
+// Stubs in the absence of librist.
 //----------------------------------------------------------------------------
 
 #if defined(TS_NO_RIST)


### PR DESCRIPTION
Changed a reference to a correct external library.

#### Affected components:
* tsRISTInputPlugin
* tsRISTOutputPlugin

#### Brief description of the proposed changes:
RIST plugins have a comment that refers to an external dependancy libsrt. Corrected that to librist.

Since the changes are in code comments, there are no functional changes and thus no test were run.