### PR TITLE
Function DtInpChannel::Read must use parameter TimeOut=-1 for blockin…

### DIFF
--- a/src/libtsduck/dektec/tsDektecInputPlugin.cpp
+++ b/src/libtsduck/dektec/tsDektecInputPlugin.cpp
@@ -949,7 +949,7 @@ size_t ts::DektecInputPlugin::receive(TSPacket* buffer, TSPacketMetadata* pkt_da
     // Receive packets.
     if (_guts->timeout_ms < 0) {
         // Receive without timeout (wait forever if no input signal).
-        status = _guts->chan.Read(reinterpret_cast<char*>(buffer), int(size));
+        status = _guts->chan.Read(reinterpret_cast<char*>(buffer), int(size), -1);
     }
     else {
         // Receive with timeout (can be null, ie. non-blocking).


### PR DESCRIPTION
…g read mode

<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->

#### Brief description of the proposed changes:
