### PR TITLE
PESDemux: Check payload length of single-packet PES units

### DIFF
--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 3227
+#define TS_COMMIT 3228


### PR DESCRIPTION
When processing the second TS packet onwards of a PES unit, the PESDemux component will check to see if it has a complete packet, and invoke the handler. When the PES unit fits within a single TS packet, this means the check is not performed, and the handler is not invoked until the start of the next unit, which flushes out the pending one.

This commit adds a length check to the path taken by the first packet, so payloads made of a single TS packet are released in a timely manner.

An example of when you might find such a packet is subtitles, where an empty page (to clear the screen) could easily fit within a single packet.

<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
#1232 

#### Affected components:
PESDemux

#### Brief description of the proposed changes:
Check the length of the PES unit in the first TS packet as well as subsequent ones, so single-packet PES units are correctly handled