### PR TITLE
Fix typos in Makefile leading to (syntax) error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ deb-tools-control:
 	    $(if $(NORIST),-e '/librist/d',-e 's/ librist,/ $(call F_GETSODPKG,librist)/') \
 	    $(if $(NOEDITLINE),-e '/libedit/d',-e 's/ libedit,/ $(call F_GETSODPKG,libedit)/') \
 	    $(if $(NOVATEK),-e '/libusb/d',-e 's/ libusb,/ $(call F_GETSODPKG,libusb)/') \
-	    $(if $(NOPCSC),-e '/libpcsc/d,-e 's/ libpcsc,/ $(call F_GETSODPKG,libpcsc)/') \
+	    $(if $(NOPCSC),-e '/libpcsc/d',-e 's/ libpcsc,/ $(call F_GETSODPKG,libpcsc)/') \
 	    $(if $(NOCURL),-e '/libcurl/d',-e 's/ libcurl,/ $(call F_GETSODPKG,libcurl)/') \
 	    $(SCRIPTSDIR)/tsduck.control >$(TMPROOT)/DEBIAN/control
 
@@ -287,7 +287,7 @@ deb-dev-control:
 	    $(if $(NORIST),-e '/librist/d',-e 's/ librist-dev,/ $(call F_GETDPKG,librist/librist.h)/') \
 	    $(if $(NOEDITLINE),-e '/libedit/d',-e 's/ libedit-dev,/ $(call F_GETDPKG,editline/readline.h)/') \
 	    $(if $(NOVATEK),-e '/libusb/d',-e 's/ libusb-dev,/ $(call F_GETDPKG,libusb.h)/') \
-	    $(if $(NOPCSC),-e '/libpcsc/d,-e 's/ libpcsc-dev,/ $(call F_GETDPKG,PCSC/reader.h)/') \
+	    $(if $(NOPCSC),-e '/libpcsc/d',-e 's/ libpcsc-dev,/ $(call F_GETDPKG,PCSC/reader.h)/') \
 	    $(if $(NOCURL),-e '/libcurl/d',-e 's/ libcurl-dev,/ $(call F_GETDPKG,curl/curl.h)/') \
 	    $(SCRIPTSDIR)/tsduck-dev.control >$(TMPROOT)/DEBIAN/control
 


### PR DESCRIPTION
#### Related issue (if any):
Not really. Although I believe the typos being fixed here were introduced while fixing #1229.

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->
Makefile

#### Brief description of the proposed changes:
My editor showed somewhat wonky syntax highlighting of _Makefile_. That lead to finding missing `'`s in targets _deb-tools-control_ and _deb-dev-control_.

Running those targets directly (with some local workarounds due to not-quite-appropriate environment for them) resulted in
```
bash: -c: line 8: unexpected EOF while looking for matching `''
```

I believe running `make NOPCSC=1 deb` would show an error in an appropriate environment.
