### PR TITLE
add makefile variable NATIVEBINDIR to be able to execute native tsxml…

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -310,6 +310,15 @@ else
     BINDIR = $(ROOTDIR)/bin/release-$(MAIN_ARCH)$(if $(HOSTNAME),-$(HOSTNAME),)$(BINDIR_SUFFIX)
 endif
 
+ifneq ($(NATIVEBINDIR),)
+    # NATIVEBINDIR is specified in input, transform it into an absolute path for recursion.
+    INNATIVEBINDIR := $(NATIVEBINDIR)
+    override NATIVEBINDIR := $(abspath $(INNATIVEBINDIR))
+    MAKEOVERRIDES := $(subst NATIVEBINDIR=$(INNATIVEBINDIR),NATIVEBINDIR=$(NATIVEBINDIR),$(MAKEOVERRIDES))
+else
+    NATIVEBINDIR = $(BINDIR)
+endif
+
 OBJDIR = $(BINDIR)/objs-$(notdir $(CURDIR))
 
 #-----------------------------------------------------------------------------

--- a/src/libtsduck/config/Makefile
+++ b/src/libtsduck/config/Makefile
@@ -63,11 +63,11 @@ $(BINDIR)/%: %
 
 # Generate the complete configuration files from separate files.
 
-$(TABLES_DEST): $(TABLES_SRC) $(TABLES_SUBS) $(BINDIR)/tsxml
-	@echo '  [GEN] $(notdir $@)'; \
-	LD_LIBRARY_PATH="$(BINDIR):$(LD_LIBRARY_PATH)" \
-	$(if $(MACOS),DYLD_LIBRARY_PATH="$(BINDIR):$(DYLD_LIBRARY_PATH)") \
-	$(BINDIR)/tsxml --merge $(TABLES_SRC) $(TABLES_SUBS) --sort _tables --sort _descriptors --uncomment -o $@
+$(TABLES_DEST): $(TABLES_SRC) $(TABLES_SUBS) $(NATIVEBINDIR)/tsxml
+	@echo '  [GEN] $(NATIVEBINDIR) $(notdir $@)'; \
+	LD_LIBRARY_PATH="$(NATIVEBINDIR):$(LD_LIBRARY_PATH)" \
+	$(if $(MACOS),DYLD_LIBRARY_PATH="$(NATIVEBINDIR):$(DYLD_LIBRARY_PATH)") \
+	$(NATIVEBINDIR)/tsxml --merge $(TABLES_SRC) $(TABLES_SUBS) --sort _tables --sort _descriptors --uncomment -o $@
 
 $(NAMES_DEST): $(NAMES_SRC)
 	@echo '  [GEN] $(notdir $@)'; \


### PR DESCRIPTION
I have read the bugreport #1250 and I’m although using cross compilation feature of TSDuck. Therefore, I would prefer option 2: “Force the usage of a natively installed tsxml”. The cross compilation is integrated in a Yocto-System which handles the build of the native tsxml to and I needed on option to be flexible to set the directory where the native tsxml is located.
This pull request adds a makefile variable NATIVEBINDIR which defaults to BINDIR if is not set. The tsxml used in the build process is executed in this location.
