### PR TITLE
Support floating point numbers in time plugin

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -15,5 +15,6 @@ Maciej Czyzkowski
 Richie Chang
 Paul Higgs
 Amos Cheung
+Anders Solberg Pedersen
 
 If you wish to contribute, please see https://tsduck.io/doxy/contributing.html

--- a/src/tsplugins/tsplugin_time.cpp
+++ b/src/tsplugins/tsplugin_time.cpp
@@ -218,12 +218,12 @@ bool ts::TimePlugin::addEvents(const UChar* opt, Status status)
         }
         else if (_relative) {
             // Decode relative time string (a number of seconds)
-            MilliSecond second = 0;
-            if (!timeString.toInteger(second)) {
+            MilliSecond milliSeconds = 0;
+            if (!timeString.toInteger(milliSeconds, UString(), 3)) {
                 tsp->error(u"invalid relative number of seconds: %s", {timeString});
                 return false;
             }
-            _events.push_back(TimeEvent(status, start_time + second * MilliSecPerSec));
+            _events.push_back(TimeEvent(status, start_time + milliSeconds));
         }
         else {
             // Decode an absolute time string


### PR DESCRIPTION
<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->
time plugin

#### Brief description of the proposed changes:
I'm using the time plugin to simulate packet drops in order to test a redundancy switch. Currently it only supports a whole number of seconds when using relative time. I'd love to be able to test with a higher precision than that, so here's my suggestion/feature request. Please let me know if there's a better way to do this instead :) And since I'm new to the tsduck code I don't know if there's a more idiomatic way to write this code.

Thanks for making this great program. I'm grateful to have an opportunity to contribute.