### PR TITLE
update libtsduck pkg-config to respect makevar CXXFLAGS_STANDARD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@
 #  - NOEDITLINE : No interactive line editing, remove dependency to libedit.
 #  - NOGITHUB   : No version check, no download, no upgrade from GitHub.
 #  - NOHWACCEL  : Disable hardware acceleration such as crypto instructions.
+#  - NOPCSTD    : Remove the std=c++11 flag from libtsduck's pkg-config file.
 #
 #  Options to define the representation of bitrates:
 #

--- a/src/libtsduck/config/Makefile
+++ b/src/libtsduck/config/Makefile
@@ -100,6 +100,7 @@ install-devel:
 	    $(if $(NOPCSC),-e 's|libpcsclite||g') \
 	    $(if $(NOCURL),-e 's|libcurl||g') \
 	    $(if $(NOEDITLINE),-e 's|libedit||g') \
+	    $(if $(NOPCSTD),-e 's| *--std=[^ ]* *| |g') \
 	    $(if $(NOVATEK),-e 's|libusb-1.0||g') \
 	    $(if $(OPENBSD)$(NETBSD),-e 's| *-ldl *| |g') \
 	    $(if $(MACOS)$(OPENBSD),-e 's| *-lrt *| |g') \


### PR DESCRIPTION
#### Related issue (if any):
Closes #1305 

#### Affected components:
libtsduck pkg-config will now output `--std=c++14` and `--std=c++20` when compiled with `CXXFLAG_STANDARD=-std=c++14` and `CXXFLAG_STANDARD=-std=c++20`, respectively.

#### Brief description of the proposed changes:

* Updates the package-config file to use a placeholder instead of a literal flag
* Updates the libtsduck makefile to replace the placeholder with the flag as set by make