### PR TITLE
EIT: change options to independantly select the 4 kinds

### DIFF
--- a/src/libtsduck/dtv/epg/tsEITOptions.h
+++ b/src/libtsduck/dtv/epg/tsEITOptions.h
@@ -21,10 +21,14 @@ namespace ts {
     //!
     enum class EITOptions {
         GEN_NONE          = 0x0000,   //!< Generate nothing.
-        GEN_ACTUAL        = 0x0001,   //!< Generate EIT actual.
-        GEN_OTHER         = 0x0002,   //!< Generate EIT other.
-        GEN_PF            = 0x0004,   //!< Generate EIT present/following.
-        GEN_SCHED         = 0x0008,   //!< Generate EIT schedule.
+        GEN_ACTUAL_PF     = 0x0001,   //!< Generate EIT actual present/following.
+        GEN_OTHER_PF      = 0x0002,   //!< Generate EIT other present/following.
+        GEN_ACTUAL_SCHED  = 0x0004,   //!< Generate EIT actual schedule.
+        GEN_OTHER_SCHED   = 0x0008,   //!< Generate EIT other schedule.
+        GEN_PF            = 0x0003,   //!< Generate all EIT present/following.
+        GEN_SCHED         = 0x000C,   //!< Generate all EIT schedule.
+        GEN_ACTUAL        = 0x0005,   //!< Generate all EIT actual.
+        GEN_OTHER         = 0x000A,   //!< Generate all EIT other.
         GEN_ALL           = 0x000F,   //!< Generate all EIT's.
         LOAD_INPUT        = 0x0010,   //!< Use input EIT's as EPG data.
         PACKET_STUFFING   = 0x0020,   //!< Insert stuffing inside TS packet at end of EIT section. Do not pack EIT sections.

--- a/src/libtsduck/dtv/signalization/tsSectionFileArgs.cpp
+++ b/src/libtsduck/dtv/signalization/tsSectionFileArgs.cpp
@@ -51,25 +51,25 @@ void ts::SectionFileArgs::defineArgs(Args& args)
               u"If the time is also specified, it is the current time for the snapshot of EIT present/following. "
               u"By default, use the oldest date in all EIT sections as base date.");
 
-    args.option(u"eit-actual");
-    args.help(u"eit-actual",
-              u"With --eit-normalization, generate EIT actual. "
-              u"If neither --eit-actual nor --eit-other are specified, both are generated.");
+    args.option(u"eit-actual-pf");
+    args.help(u"eit-actual-pf",
+              u"With --eit-normalization, generate EIT actual p/f. "
+              u"If no option is specified, all EIT sections are generated.");
 
-    args.option(u"eit-other");
-    args.help(u"eit-other",
-              u"With --eit-normalization, generate EIT other. "
-              u"If neither --eit-actual nor --eit-other are specified, both are generated.");
+    args.option(u"eit-other-pf");
+    args.help(u"eit-other-pf",
+              u"With --eit-normalization, generate EIT other p/f. "
+              u"If no option is specified, all EIT sections are generated.");
 
-    args.option(u"eit-pf");
-    args.help(u"eit-pf",
-              u"With --eit-normalization, generate EIT p/f. "
-              u"If neither --eit-pf nor --eit-schedule are specified, both are generated.");
+    args.option(u"eit-actual-schedule");
+    args.help(u"eit-actual-schedule",
+              u"With --eit-normalization, generate EIT actual schedule. "
+              u"If no option is specified, all EIT sections are generated.");
 
-    args.option(u"eit-schedule");
-    args.help(u"eit-schedule",
-              u"With --eit-normalization, generate EIT schedule. "
-              u"If neither --eit-pf nor --eit-schedule are specified, both are generated.");
+    args.option(u"eit-other-schedule");
+    args.help(u"eit-other-schedule",
+              u"With --eit-normalization, generate EIT other schedule. "
+              u"If no option is specified, all EIT sections are generated.");
 
     args.option(u"pack-and-flush");
     args.help(u"pack-and-flush",
@@ -98,25 +98,21 @@ bool ts::SectionFileArgs::loadArgs(DuckContext& duck, Args& args)
 
     // Combination of EIT generation options.
     eit_options = EITOptions::GEN_NONE;
-    if (args.present(u"eit-actual")) {
-        eit_options |= EITOptions::GEN_ACTUAL;
+    if (args.present(u"eit-actual-pf")) {
+        eit_options |= EITOptions::GEN_ACTUAL_PF;
     }
-    if (args.present(u"eit-other")) {
-        eit_options |= EITOptions::GEN_OTHER;
+    if (args.present(u"eit-other-pf")) {
+        eit_options |= EITOptions::GEN_OTHER_PF;
     }
-    if (!(eit_options & (EITOptions::GEN_ACTUAL | EITOptions::GEN_OTHER))) {
-        // Generate EIT actual and other by default.
-        eit_options |= EITOptions::GEN_ACTUAL | EITOptions::GEN_OTHER;
+    if (args.present(u"eit-actual-schedule")) {
+        eit_options |= EITOptions::GEN_ACTUAL_SCHED;
     }
-    if (args.present(u"eit-pf")) {
-        eit_options |= EITOptions::GEN_PF;
+    if (args.present(u"eit-other-schedule")) {
+        eit_options |= EITOptions::GEN_OTHER_SCHED;
     }
-    if (args.present(u"eit-schedule")) {
-        eit_options |= EITOptions::GEN_SCHED;
-    }
-    if (!(eit_options & (EITOptions::GEN_PF | EITOptions::GEN_SCHED))) {
-        // Generate EIT p/f and schedule by default.
-        eit_options |= EITOptions::GEN_PF | EITOptions::GEN_SCHED;
+    if (!(eit_options & EITOptions::GEN_ALL)) {
+        // Generate all sections by default.
+        eit_options |= EITOptions::GEN_ALL;
     }
 
     return true;

--- a/src/tsplugins/tsplugin_eitinject.cpp
+++ b/src/tsplugins/tsplugin_eitinject.cpp
@@ -139,9 +139,13 @@ ts::EITInjectPlugin::EITInjectPlugin(TSP* tsp_) :
 {
     duck.defineArgsForCharset(*this);
 
-    option(u"actual");
-    help(u"actual",
-         u"Generate EIT actual. If neither --actual nor --other are specified, both are generated.");
+    option(u"actual-pf");
+    help(u"actual-pf",
+         u"Generate EIT actual p/f. If no option is specified, all EIT sections are generated.");
+
+    option(u"actual-schedule");
+    help(u"actual-schedule",
+         u"Generate EIT actual schedule. If no option is specified, all EIT sections are generated.");
 
     option<BitRate>(u"bitrate", 'b');
     help(u"bitrate",
@@ -220,13 +224,13 @@ ts::EITInjectPlugin::EITInjectPlugin(TSP* tsp_) :
          u"poll notifications when a file is being written and his size modified at "
          u"each poll. The default is " + UString::Decimal(DEFAULT_MIN_STABLE_DELAY) + u" ms.");
 
-    option(u"other");
-    help(u"other",
-         u"Generate EIT other. If neither --actual nor --other are specified, both are generated.");
+    option(u"other-pf");
+    help(u"other-pf",
+         u"Generate EIT other p/f. If no option is specified, all EIT sections are generated.");
 
-    option(u"pf");
-    help(u"pf",
-         u"Generate EIT p/f. If neither --pf nor --schedule are specified, both are generated.");
+    option(u"other-schedule");
+    help(u"other-schedule",
+         u"Generate EIT actual schedule. If no option is specified, all EIT sections are generated.");
 
     option(u"poll-interval", 0, UNSIGNED);
     help(u"poll-interval", u"milliseconds",
@@ -239,10 +243,6 @@ ts::EITInjectPlugin::EITInjectPlugin(TSP* tsp_) :
          u"EIT schedule for events in the prime period (i.e. the next few days) "
          u"are repeated more frequently than EIT schedule for later events. "
          u"The default is " + UString::Decimal(EITRepetitionProfile::SatelliteCable.prime_days) + u" days.");
-
-    option(u"schedule");
-    help(u"schedule",
-         u"Generate EIT schedule. If neither --pf nor --schedule are specified, both are generated.");
 
     option(u"stuffing");
     help(u"stuffing",
@@ -310,25 +310,21 @@ bool ts::EITInjectPlugin::getOptions()
 
     // Combination of EIT generation options.
     _eit_options = EITOptions::GEN_NONE;
-    if (present(u"actual")) {
-        _eit_options |= EITOptions::GEN_ACTUAL;
+    if (present(u"actual-pf")) {
+        _eit_options |= EITOptions::GEN_ACTUAL_PF;
     }
-    if (present(u"other")) {
-        _eit_options |= EITOptions::GEN_OTHER;
+    if (present(u"other-pf")) {
+        _eit_options |= EITOptions::GEN_OTHER_PF;
     }
-    if (!(_eit_options & (EITOptions::GEN_ACTUAL | EITOptions::GEN_OTHER))) {
-        // Generate EIT actual and other by default.
-        _eit_options |= EITOptions::GEN_ACTUAL | EITOptions::GEN_OTHER;
+    if (present(u"actual-schedule")) {
+        _eit_options |= EITOptions::GEN_ACTUAL_SCHED;
     }
-    if (present(u"pf")) {
-        _eit_options |= EITOptions::GEN_PF;
+    if (present(u"other-schedule")) {
+        _eit_options |= EITOptions::GEN_OTHER_SCHED;
     }
-    if (present(u"schedule")) {
-        _eit_options |= EITOptions::GEN_SCHED;
-    }
-    if (!(_eit_options & (EITOptions::GEN_PF | EITOptions::GEN_SCHED))) {
+    if (!(_eit_options & EITOptions::GEN_ALL)) {
         // Generate EIT p/f and schedule by default.
-        _eit_options |= EITOptions::GEN_PF | EITOptions::GEN_SCHED;
+        _eit_options |= EITOptions::GEN_ALL;
     }
     if (present(u"incoming-eits")) {
         _eit_options |= EITOptions::LOAD_INPUT;

--- a/src/tstools/tseit.cpp
+++ b/src/tstools/tseit.cpp
@@ -135,22 +135,22 @@ ts::EITMainOptions::EITMainOptions(int argc, char *argv[]) :
     cmd->help(u"terrestrial", u"Use the EIT cycle profile for terrestrial networks as specified in ETSI TS 101 211.");
     cmd->option(u"satellite");
     cmd->help(u"satellite", u"Use the EIT cycle profile for satellite and cable networks as specified in ETSI TS 101 211.");
-    cmd->option(u"pf");
-    cmd->help(u"pf", u"Enable the generation of EIT p/f.");
-    cmd->option(u"no-pf");
-    cmd->help(u"no-pf", u"Disable the generation of EIT p/f.");
-    cmd->option(u"schedule");
-    cmd->help(u"schedule", u"Enable the generation of EIT schedule.");
-    cmd->option(u"no-schedule");
-    cmd->help(u"no-schedule", u"Disable the generation of EIT schedule.");
-    cmd->option(u"actual");
-    cmd->help(u"actual", u"Enable the generation of EIT actual.");
-    cmd->option(u"no-actual");
-    cmd->help(u"no-actual", u"Disable the generation of EIT actual.");
-    cmd->option(u"other");
-    cmd->help(u"other", u"Enable the generation of EIT other.");
-    cmd->option(u"no-other");
-    cmd->help(u"no-other", u"Disable the generation of EIT other.");
+    cmd->option(u"actual-pf");
+    cmd->help(u"actual pf", u"Enable the generation of actual EIT p/f.");
+    cmd->option(u"no-actual-pf");
+    cmd->help(u"no-actual-pf", u"Disable the generation of actual EIT p/f.");
+    cmd->option(u"other-pf");
+    cmd->help(u"other pf", u"Enable the generation of other EIT p/f.");
+    cmd->option(u"no-other-pf");
+    cmd->help(u"no-other-pf", u"Disable the generation of other EIT p/f.");
+    cmd->option(u"actual-schedule");
+    cmd->help(u"actual schedule", u"Enable the generation of actual EIT schedule.");
+    cmd->option(u"no-actual-schedule");
+    cmd->help(u"no-actual-schedule", u"Disable the generation of actual EIT schedule.");
+    cmd->option(u"other-schedule");
+    cmd->help(u"other schedule", u"Enable the generation of other EIT schedule.");
+    cmd->option(u"no-other-schedule");
+    cmd->help(u"no-other-schedule", u"Disable the generation of other EIT schedule.");
     cmd->option(u"ts-id", 0, UINT16);
     cmd->help(u"ts-id", u"Set the actual transport stream id.");
     cmd->option<BitRate>(u"ts-bitrate");
@@ -426,36 +426,36 @@ ts::CommandStatus ts::EITCommand::dump(const UString& command, Args& args)
 ts::CommandStatus ts::EITCommand::set(const UString& command, Args& args)
 {
     bool set_options = false;
-    if (args.present(u"pf")) {
-        _eit_options |= EITOptions::GEN_PF;
+    if (args.present(u"actual-pf")) {
+        _eit_options |= EITOptions::GEN_ACTUAL_PF;
         set_options = true;
     }
-    if (args.present(u"no-pf")) {
-        _eit_options &= ~EITOptions::GEN_PF;
+    if (args.present(u"no-actual-pf")) {
+        _eit_options &= ~EITOptions::GEN_ACTUAL_PF;
         set_options = true;
     }
-    if (args.present(u"schedule")) {
-        _eit_options |= EITOptions::GEN_SCHED;
+    if (args.present(u"other-pf")) {
+        _eit_options |= EITOptions::GEN_OTHER_PF;
         set_options = true;
     }
-    if (args.present(u"no-schedule")) {
-        _eit_options &= ~EITOptions::GEN_SCHED;
+    if (args.present(u"no-other-pf")) {
+        _eit_options &= ~EITOptions::GEN_OTHER_PF;
         set_options = true;
     }
-    if (args.present(u"actual")) {
-        _eit_options |= EITOptions::GEN_ACTUAL;
+    if (args.present(u"actual-schedule")) {
+        _eit_options |= EITOptions::GEN_ACTUAL_SCHED;
         set_options = true;
     }
-    if (args.present(u"no-actual")) {
-        _eit_options &= ~EITOptions::GEN_ACTUAL;
+    if (args.present(u"no-actual-schedule")) {
+        _eit_options &= ~EITOptions::GEN_ACTUAL_SCHED;
         set_options = true;
     }
-    if (args.present(u"other")) {
-        _eit_options |= EITOptions::GEN_OTHER;
+    if (args.present(u"other-schedule")) {
+        _eit_options |= EITOptions::GEN_OTHER_SCHED;
         set_options = true;
     }
-    if (args.present(u"no-other")) {
-        _eit_options &= ~EITOptions::GEN_OTHER;
+    if (args.present(u"no-other-schedule")) {
+        _eit_options &= ~EITOptions::GEN_OTHER_SCHED;
         set_options = true;
     }
     if (set_options) {


### PR DESCRIPTION
#### Related issue (if any):
The current options for EITGenerator only allow to select either actual or other, and either pf or schedule. You have no way for instance to select actual pf, other pf and actual shedule but not other schedule. However this is what you are supposed to do on eg. the French DTT.

#### Affected components:
EITGenerator, eitinject tsp plug-in and tseit application.

#### Brief description of the proposed changes:
This commit makes 4 distinct options, one for each kind. It does however change the CLI of tsp and tseit. I am unsure what the policy of the project is regarding such changes, so apply with caution.