### PR TITLE
Srtstatistics corrected spell error in elapsed time

### DIFF
--- a/src/libtsduck/base/network/tsSRTSocket.cpp
+++ b/src/libtsduck/base/network/tsSRTSocket.cpp
@@ -1169,7 +1169,7 @@ bool ts::SRTSocket::reportStatistics(SRTStatMode mode, Report& report)
         // Statistics in JSON format.
         json::Object root;
         if ((mode & SRTStatMode::RECEIVE) != SRTStatMode::NONE) {
-            root.query(u"receive.total", true).add(u"elapsed-ms'", stats.msTimeStamp);
+            root.query(u"receive.total", true).add(u"elapsed-ms", stats.msTimeStamp);
             root.query(u"receive.total", true).add(u"bytes", stats.byteRecvTotal);
             root.query(u"receive.total", true).add(u"packets", stats.pktRecvTotal);
             root.query(u"receive.total", true).add(u"lost-packets", stats.pktRcvLossTotal);


### PR DESCRIPTION
<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->

#### Brief description of the proposed changes:
