### PR TITLE
fix elapsed-time spell also in sender

### DIFF
--- a/src/libtsduck/base/network/tsSRTSocket.cpp
+++ b/src/libtsduck/base/network/tsSRTSocket.cpp
@@ -1221,7 +1221,7 @@ bool ts::SRTSocket::reportStatistics(SRTStatMode mode, Report& report)
 #endif
         }
         if ((mode & SRTStatMode::SEND) != SRTStatMode::NONE) {
-            root.query(u"send.total", true).add(u"elapsed-ms'", stats.msTimeStamp);
+            root.query(u"send.total", true).add(u"elapsed-ms", stats.msTimeStamp);
             root.query(u"send.total", true).add(u"bytes", stats.byteSentTotal);
             root.query(u"send.total", true).add(u"packets", stats.pktSentTotal);
             root.query(u"send.total", true).add(u"retransmit-packets", stats.pktRetransTotal);


### PR DESCRIPTION
<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/doxy/contributing.html
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->

#### Brief description of the proposed changes:
