### PR TITLE
Add support for --compressed option using libcurl

### DIFF
--- a/src/libtsduck/base/network/tsWebRequest.cpp
+++ b/src/libtsduck/base/network/tsWebRequest.cpp
@@ -87,6 +87,16 @@ void ts::WebRequest::setUserAgent(const UString& name)
 
 
 //----------------------------------------------------------------------------
+// Enable compression.
+//----------------------------------------------------------------------------
+
+void ts::WebRequest::enableCompression()
+{
+    _useCompression = true;
+}
+
+
+//----------------------------------------------------------------------------
 // Set timeout options.
 //----------------------------------------------------------------------------
 
@@ -215,6 +225,9 @@ void ts::WebRequest::setArgs(const ts::WebRequestArgs& args)
     }
     if (args.useCookies) {
         enableCookies(args.cookiesFile);
+    }
+    if (args.useCompression) {
+        enableCompression();
     }
 }
 

--- a/src/libtsduck/base/network/tsWebRequest.h
+++ b/src/libtsduck/base/network/tsWebRequest.h
@@ -156,6 +156,12 @@ namespace ts {
         void setUserAgent(const UString& name = UString());
 
         //!
+        //! Enable compression.
+        //! Compression is disabled by default.
+        //!
+        void enableCompression();
+
+        //!
         //! Get the current user agent name to use in HTTP headers.
         //! @return A constant reference to the user agent name to use in HTTP headers.
         //!
@@ -351,6 +357,7 @@ namespace ts {
         uint16_t      _proxyPort = 0;
         UString       _proxyUser {};
         UString       _proxyPassword {};
+        bool          _useCompression = false;
         UString       _cookiesFileName {};
         bool          _useCookies = false;
         bool          _deleteCookiesFile = false; // delete the cookies file on close

--- a/src/libtsduck/base/network/tsWebRequestArgs.cpp
+++ b/src/libtsduck/base/network/tsWebRequestArgs.cpp
@@ -46,6 +46,11 @@ void ts::WebRequestArgs::defineArgs(Args& args)
     args.option(u"user-agent", 0, Args::STRING);
     args.help(u"user-agent", u"'string'",
               u"Specify the user agent string to send in HTTP requests.");
+
+    args.option(u"compressed",0);
+    args.help(u"compressed",
+              u"Accept compressed HTTP responses. By default, compressed responses are "
+              u"not accepted.");
 }
 
 
@@ -64,5 +69,6 @@ bool ts::WebRequestArgs::loadArgs(DuckContext& duck, Args& args)
     args.getValue(proxyUser, u"proxy-user");
     args.getValue(proxyPassword, u"proxy-password");
     args.getValue(userAgent, u"user-agent");
+    useCompression = args.present(u"compressed");
     return true;
 }

--- a/src/libtsduck/base/network/tsWebRequestArgs.h
+++ b/src/libtsduck/base/network/tsWebRequestArgs.h
@@ -41,6 +41,7 @@ namespace ts {
         UString       userAgent {};          //!< -\-user-agent
         bool          useCookies = true;     //!< Use cookies, no command line options, true by default
         UString       cookiesFile {};        //!< Cookies files (Linux only), no command line options
+        bool          useCompression = false; //!< -\-compressed
 
         //!
         //! Add command line option definitions in an Args.

--- a/src/libtsduck/base/unix/tsWebRequestGuts.cpp
+++ b/src/libtsduck/base/unix/tsWebRequestGuts.cpp
@@ -413,6 +413,11 @@ bool ts::WebRequest::SystemGuts::startTransfer(CertState certState)
             status = ::curl_easy_setopt(_curl, CURLOPT_USERAGENT, _request._userAgent.toUTF8().c_str());
         }
 
+        // Set compression.
+        if (status == ::CURLE_OK && _request._useCompression) {
+            status = ::curl_easy_setopt(_curl, CURLOPT_ACCEPT_ENCODING, "gzip, deflate");
+        }
+
         // Set the starting URL.
         if (status == ::CURLE_OK) {
             status = ::curl_easy_setopt(_curl, CURLOPT_URL, _request._originalURL.toUTF8().c_str());


### PR DESCRIPTION

#### Affected components:
http (input) plugin

#### Brief description of the proposed changes:
add support for retrieving compressed content 