### PR TITLE
Add support for custom HTTP headers in HTTP/HLS communications

### DIFF
--- a/src/libtsduck/base/network/tsWebRequest.cpp
+++ b/src/libtsduck/base/network/tsWebRequest.cpp
@@ -195,6 +195,9 @@ void ts::WebRequest::setArgs(const ts::WebRequestArgs& args)
     if (args.useCompression) {
         enableCompression();
     }
+    for (const auto& it : args.headers) {
+        setRequestHeader(it.first, it.second);
+    }
 }
 
 
@@ -204,6 +207,12 @@ void ts::WebRequest::setArgs(const ts::WebRequestArgs& args)
 
 void ts::WebRequest::setRequestHeader(const UString& name, const UString& value)
 {
+    // Check for duplicates on key AND value (multiple headers with the same key are permitted)
+    for (const auto& header: _requestHeaders) {
+        if (header.first == name && header.second == value) {
+            return;
+        }
+    }
     _requestHeaders.insert(std::make_pair(name, value));
 }
 

--- a/src/libtsduck/base/network/tsWebRequestArgs.h
+++ b/src/libtsduck/base/network/tsWebRequestArgs.h
@@ -32,16 +32,17 @@ namespace ts {
         WebRequestArgs() = default;
 
         // Public fields, by options.
-        MilliSecond   connectionTimeout = 0;  //!< -\-connection-timeout
-        MilliSecond   receiveTimeout = 0;     //!< -\-receive-timeout
-        uint16_t      proxyPort = 0;          //!< -\-proxy-port
-        UString       proxyHost {};           //!< -\-proxy-host
-        UString       proxyUser {};           //!< -\-proxy-user
-        UString       proxyPassword {};       //!< -\-proxy-password
-        UString       userAgent {};           //!< -\-user-agent
-        bool          useCookies = true;      //!< Use cookies, no command line options, true by default
-        UString       cookiesFile {};         //!< Cookies files (Linux only), no command line options
-        bool          useCompression = false; //!< -\-compressed
+        MilliSecond   connectionTimeout = 0;        //!< -\-connection-timeout
+        MilliSecond   receiveTimeout = 0;           //!< -\-receive-timeout
+        uint16_t      proxyPort = 0;                //!< -\-proxy-port
+        UString       proxyHost {};                 //!< -\-proxy-host
+        UString       proxyUser {};                 //!< -\-proxy-user
+        UString       proxyPassword {};             //!< -\-proxy-password
+        UString       userAgent {};                 //!< -\-user-agent
+        bool          useCookies = true;            //!< Use cookies, no command line options, true by default
+        UString       cookiesFile {};               //!< Cookies files (Linux only), no command line options
+        bool          useCompression = false;       //!< -\-compressed
+        std::multimap<UString,UString> headers {};  //!< -\-headers
 
         //!
         //! Add command line option definitions in an Args.


### PR DESCRIPTION
#### Affected components:
HLS / HTTP input

#### Brief description of the proposed changes:

Allow the user to set custom header/s in HTTP requests - I added this because a particular HLS stream I needed to ingest was using a custom token-based authentication scheme.

Example usage:

```
tsp -I hls --headers 'x-affiliate-auth-key: {token}' https://{url}/index.m3u8 -O file  /tmp/test.mp4
```

Several headers can be added with multiple `--headers` entries.
