### PR TITLE
parse DVB-I info in URI linkage descriptor

### DIFF
--- a/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.cpp
@@ -237,7 +237,7 @@ bool ts::URILinkageDescriptor::DVB_I_Info::fromXML(const xml::Element* element)
     }
     if (ok) {
         if ((end_point_type != END_POINT_SERVICE_LIST_EXTENDED) && (service_list_name.has_value() || service_list_provider_name.has_value())) {
-            element->report().error(u"service_list_name and service_list_provider_name only permitted when end_point_type=0x0X in <%s>, line %d", {END_POINT_SERVICE_LIST_EXTENDED, element->name(), element->lineNumber()});
+            element->report().error(u"service_list_name and service_list_provider_name only permitted when end_point_type=0x%X in <%s>, line %d", {END_POINT_SERVICE_LIST_EXTENDED, element->name(), element->lineNumber()});
             ok = false;
         }
     }

--- a/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.h
@@ -27,12 +27,12 @@ namespace ts {
     public:
         class TSDUCKDLL DVB_I_Info
         {
-            TS_DEFAULT_COPY_MOVE(DVB_I_Info);
+        //!
+        //! DVB-I_info() structure conveyed in private_data when uri_linkage_type = 0x03
+        //
+        TS_DEFAULT_COPY_MOVE(DVB_I_Info);
         public:
-            //!
-            //! DVB-I_info() structure conveyed in private_data when uri_linkage_type = 0x03
-            //
-            // DVB_I_Info public members:
+             // DVB_I_Info public members:
             uint8_t                end_point_type = 0;              //!< type of list signalled by the URI
             std::optional<UString> service_list_name {};            //!< name of the service list referenced by the uri
             std::optional<UString> service_list_provider_name {};   //!< name of the provider of the service list referenced by the uri
@@ -42,11 +42,10 @@ namespace ts {
             //!
             DVB_I_Info();
             //!
-            //! Constructor from a binary descriptor.
-            //! @param [in,out] duck TSDuck execution context.
-            //! @param [in] bin A binary descriptor to deserialize.
+            //! Constructor from binary descriptor data.
+            //! @param [in] buf A binary descriptor to deserialize.
             //!
-            DVB_I_Info(PSIBuffer& buf) : DVB_I_Info() { deserialize(buf); };
+            DVB_I_Info(PSIBuffer& buf) : DVB_I_Info() { deserialize(buf); }
 
             //! @cond nodoxygen
             void clearContent(void);

--- a/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.h
@@ -13,6 +13,7 @@
 
 #pragma once
 #include "tsAbstractDescriptor.h"
+#include "tsUString.h"
 #include "tsByteBlock.h"
 
 namespace ts {
@@ -24,11 +25,45 @@ namespace ts {
     class TSDUCKDLL URILinkageDescriptor : public AbstractDescriptor
     {
     public:
+        class TSDUCKDLL DVB_I_Info
+        {
+            TS_DEFAULT_COPY_MOVE(DVB_I_Info);
+        public:
+            //!
+            //! DVB-I_info() structure conveyed in private_data when uri_linkage_type = 0x03
+            //
+            // DVB_I_Info public members:
+            uint8_t                end_point_type = 0;              //!< type of list signalled by the URI
+            std::optional<UString> service_list_name {};            //!< name of the service list referenced by the uri
+            std::optional<UString> service_list_provider_name {};   //!< name of the provider of the service list referenced by the uri
+
+            //!
+            //! Default constructor.
+            //!
+            DVB_I_Info();
+            //!
+            //! Constructor from a binary descriptor.
+            //! @param [in,out] duck TSDuck execution context.
+            //! @param [in] bin A binary descriptor to deserialize.
+            //!
+            DVB_I_Info(PSIBuffer& buf) : DVB_I_Info() { deserialize(buf); };
+
+            //! @cond nodoxygen
+            void clearContent(void);
+            void serialize(PSIBuffer&) const;
+            void deserialize(PSIBuffer&);
+            void toXML(xml::Element*) const;
+            bool fromXML(const xml::Element*);
+            void display(TablesDisplay&, PSIBuffer&, const UString&);
+            //! @endcond
+        };
+        //
         // URILinkageDescriptor public members:
-        uint8_t   uri_linkage_type = 0;      //!< URI linkage type.
-        UString   uri {};                    //!< The URI.
-        uint16_t  min_polling_interval = 0;  //!< Valid when uri_linkage_type == 0x00 or 0x01.
-        ByteBlock private_data {};           //!< Private data.
+        uint8_t                   uri_linkage_type = 0;     //!< URI linkage type.
+        UString                   uri {};                   //!< The URI.
+        uint16_t                  min_polling_interval = 0; //!< Valid when uri_linkage_type == 0x00 or 0x01.
+        std::optional<DVB_I_Info> dvb_i_private_data {};    //!< Valid when uri_linkage_type == 0x03.
+        ByteBlock                 private_data {};          //!< Private data.
 
         //!
         //! Default constructor.

--- a/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.names
+++ b/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.names
@@ -3,6 +3,16 @@ Bits = 8
 0x00 = Online SDT (OSDT) for CI Plus
 0x01 = DVB-IPTV SD&S
 0x02 = Material Resolution Server (MRS) for companion screen applications
-0x03-0x5F = Reserved for registration to DVB specifications
+0x03 = DVB-I
+0x04-0x5F = Reserved for registration to DVB specifications
 0x60-0x7F = Reserved for registration to standardised systems through the DVB Project Office
 0x80-0xFF =  user defined
+
+[URI_linkage_descriptor.DVB_I_Endpoint_type]
+Bits = 8
+# DVB A177, ETSI TS 103 770 table 2
+0x00 = Not Used
+0x01 = DVB-I Service List
+0x02 = DVB-I Service List Registry query
+0x03 = DVB-I Service List with list name and provider name
+0x04-0xFF = Reserved for future use

--- a/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.xml
@@ -6,6 +6,10 @@
         uri_linkage_type="uint8, required"
         uri="string, required"
         min_polling_interval="uint16, optional">
+      <DVB_I_linkage
+        end_point_type="uint8, required"
+        service_list_name="string, optional"
+        service_list_provider_name="string, optional"/>
       <private_data>
         Hexadecimal content
       </private_data>

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -23,4 +23,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 3550
+#define TS_COMMIT 3551

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -23,4 +23,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 3545
+#define TS_COMMIT 3546

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -23,4 +23,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 3546
+#define TS_COMMIT 3550

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -23,4 +23,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 3544
+#define TS_COMMIT 3545


### PR DESCRIPTION
#### Affected components:
DVB URI Linkage Descriptor

#### Brief description of the proposed changes:
For URI Linkage Descriptor used with DVB-I (uri_linkage_type=0x03) parse the private_data according to DVB Bluebook A177 / ETSI TS 103 770