### PR TITLE
Fixed heap buffer overflow and invalid behaviour in handleInvalidSection

### DIFF
--- a/src/libtsduck/dtv/signalization/tsTablesLogger.cpp
+++ b/src/libtsduck/dtv/signalization/tsTablesLogger.cpp
@@ -815,7 +815,7 @@ void ts::TablesLogger::handleInvalidSection(SectionDemux& demux, const DemuxedDa
     if (sec_size > 0 && sec_size != size) {
         reason.format(u"invalid section size: %d, data size: %d", {sec_size, size});
     }
-    else if (is_long && sec_size > 4 && CRC32(data, sec_size - 4) != GetUInt32(data + sec_size)) {
+    else if (is_long && sec_size > 4 && CRC32(data, sec_size - 4) != GetUInt32(data + sec_size - 4)) {
         reason = u"invalid CRC32, corrupted section";
     }
     else if (is_long && data[6] > data[7]) {


### PR DESCRIPTION
This patch fixes heap buffer overflow found in handleInvalidSection() by AddressSanitizer in test-002. Also it fixes handleInvalidSection behavior when mpeg_sect CRC32 is correct.

Fixed heap overflow:

ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61600000718e at pc 0x7f294980c220 bp 0x7ffdb416a7d0 sp 0x7ffdb416a7c8 READ of size 1 at 0x61600000718e thread T0
    #0 0x7f294980c21f in ts::GetUInt32BE(void const*) base/types/tsMemory.cpp:173
    #1 0x7f2949e136dd in ts::GetUInt32(void const*) base/types/tsMemory.h:335
    #2 0x7f2949e136dd in ts::TablesLogger::handleInvalidSection(ts::SectionDemux&, ts::DemuxedData const&) dtv/signalization/tsTablesLogger.cpp:818
    #3 0x7f2949b73605 in ts::SectionDemux::processPacket(ts::TSPacket const&) dtv/demux/tsSectionDemux.cpp:528
    #4 0x7f2949b73de4 in ts::SectionDemux::feedPacket(ts::TSPacket const&) dtv/demux/tsSectionDemux.cpp:211
    #5 0x7f2949e0d780 in ts::TablesLogger::feedPacket(ts::TSPacket const&) dtv/signalization/tsTablesLogger.cpp:503
    #6 0x55dc91115427 in MainCode(int, char**) tsduck/src/tstools/tstables.cpp:98
...


#### Related issue (if any):
no related issue

#### Affected components:
TSDuck library

#### Brief description of the proposed changes:
Please see above