### PR TITLE
allow private data in URI Linkage Descriptor for DVB-I

### DIFF
--- a/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.h
@@ -25,7 +25,7 @@ namespace ts {
         URI_LINKAGE_ONLINE_SDT = 0x00,  //!< Online SDT (OSDT) for CI Plus, ETSI TS 102 606-2
         URI_LINKAGE_IPTV_SDnS  = 0x01,  //!< DVB-IPTV SD&S, ETSI TS 102 034
         URI_LINKAGE_MRS        = 0x02,  //!< Material Resolution Server (MRS) for companion screen applications, CENELEC EN 50221
-        URI_LINKAGE_DVB_I      = 0x03,  //!< DVB-I, DVB Bluebook A177, ETSI TS 193 770
+        URI_LINKAGE_DVB_I      = 0x03,  //!< DVB-I, DVB Bluebook A177, ETSI TS 103 770
     };
 
     //!
@@ -59,6 +59,7 @@ namespace ts {
             uint8_t                end_point_type = 0;              //!< type of list signalled by the URI
             std::optional<UString> service_list_name {};            //!< name of the service list referenced by the uri
             std::optional<UString> service_list_provider_name {};   //!< name of the provider of the service list referenced by the uri
+            ByteBlock              private_data {};                 //!< Private data.
 
             //!
             //! Default constructor.

--- a/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsURILinkageDescriptor.xml
@@ -10,7 +10,11 @@
       <DVB_I_linkage
           end_point_type="uint8, required"
           service_list_name="string, optional"
-          service_list_provider_name="string, optional"/>
+          service_list_provider_name="string, optional">
+          <private_data>
+            Hexadecimal content
+          </private_data>
+      </DVB_I_linkage>
       <private_data>
         Hexadecimal content
       </private_data>

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -23,4 +23,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 3586
+#define TS_COMMIT 3587


### PR DESCRIPTION
#### Related issue (if any):
None

#### Affected components:
all

#### Brief description of the proposed changes:
Recent update to DVB-I (DVB Bluebook A177r6 - expected to be ETSI TS 103 770 v1.2.1) allows private data as additional trailing bytes in the DVB-I Info() - for backward compatability purposes.