### PR TITLE
Added ASAN make flag (Address Sanitizer), tests using asan

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,6 +50,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         compiler: [gcc, clang]
         std: [17, 20]
+        asan: [false, true]
         include:
         - os: ubuntu-latest
           compiler: clang
@@ -59,13 +60,27 @@ jobs:
           # between steps or even the middle of a step. This breaks the naming scheme
           # of the build directory for binaries. As a consequence, we force BINDIR=bin.
           bindir: bin
+        - asan: true
+          asan_flag: true
+          # set compiler flag (asan_flag)
         exclude:
         - os: macos-latest
           compiler: gcc
           # Don't use gcc on macOS.
-    name: Build on ${{ matrix.os }} with ${{ matrix.compiler }}, C++${{ matrix.std }}
+        - os: macos-latest
+          asan: true
+          # Exlude asan build on macOS
+        - os: ubuntu-latest
+          asan: true
+          std: 17
+          # Exlude asan build on ubuntu with C++17 standard
+    name: Build on ${{ matrix.os }} with ${{ matrix.compiler }}, C++${{ matrix.std }}, asan=${{ matrix.asan }}
     runs-on: ${{ matrix.os }}
     env:
+      ASAN: ${{ matrix.asan_flag }}
+      # ASAN env var is used as Makefile flag to build tsduck
+      ASAN_RUN: ${{ matrix.asan_flag }}
+      # ASAN_RUN env var is used to disable tests not compatible with asan
       LLVM: ${{ matrix.llvm }}
       BINDIR: ${{ matrix.bindir }}
       CXXFLAGS_STANDARD: -std=c++${{ matrix.std }}

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -511,6 +511,16 @@ else
     LDFLAGS_DEBUG =
 endif
 
+# Compilation flags for code sanitizing using asan with default optimization.
+
+ifneq ($(ASAN),)
+    CXXFLAGS_ASAN = -fsanitize=address -g3
+    LDFLAGS_ASAN = -fsanitize=address -g3
+else
+    CXXFLAGS_ASAN =
+    LDFLAGS_ASAN =
+endif
+
 # Compilation flags for code coverage using gcov.
 
 ifneq ($(GCOV),)
@@ -543,10 +553,10 @@ LDLIBS += -lstdc++ -lpthread $(if $(MACOS)$(OPENBSD),,-lrt) -lm
 # Global compilation flags.
 # Additional flags can be passed on the "make" command line using xxFLAGS_EXTRA.
 
-CXXFLAGS = $(CXXFLAGS_DEBUG) $(CXXFLAGS_M32) $(CXXFLAGS_GCOV) $(CXXFLAGS_GPROF) $(CXXFLAGS_WARNINGS) \
+CXXFLAGS = $(CXXFLAGS_DEBUG) $(CXXFLAGS_M32) $(CXXFLAGS_ASAN) $(CXXFLAGS_GCOV) $(CXXFLAGS_GPROF) $(CXXFLAGS_WARNINGS) \
            $(CXXFLAGS_SECURITY) $(CXXFLAGS_INCLUDES) $(CXXFLAGS_TARGET) $(CXXFLAGS_FPIC) $(CXXFLAGS_STANDARD) \
            $(CXXFLAGS_CROSS) $(CXXFLAGS_PTHREAD) $(CXXFLAGS_EXTRA)
-LDFLAGS  = $(LDFLAGS_DEBUG) $(LDFLAGS_M32) $(LDFLAGS_GCOV) $(LDFLAGS_GPROF) $(CXXFLAGS_TARGET) \
+LDFLAGS  = $(LDFLAGS_DEBUG) $(LDFLAGS_M32) $(LDFLAGS_ASAN) $(LDFLAGS_GCOV) $(LDFLAGS_GPROF) $(CXXFLAGS_TARGET) \
            $(LDFLAGS_CROSS) $(LDFLAGS_PTHREAD) $(LDFLAGS_EXTRA)
 ARFLAGS  = rc$(if $(MACOS),,U) $(ARFLAGS_EXTRA)
 


### PR DESCRIPTION
#### Related issue (if any):
no related issue (some fixed problems could be found using asan)

#### Affected components:
CI, Makefile for all components

#### Brief description of the proposed changes:
This patch introduces asan build and execution tests using asan build. This issue https://github.com/tsduck/tsduck/commit/614fae300ce50e9c57b901cf03b6787a7cad3fbf was found using asan build and existed tests. Some other reported issues could be found using this technique. Also, asan build might be combined with fuzzing tests (not prepared yet for merging)

For demo purposes, I've executed tests with asan on tsduck build on version before 614fae300ce50e9c57b901cf03b6787a7cad3fbf:  https://github.com/svlobanov/tsduck/actions/runs/7481649692/job/20363643633 (see 'Run tests suite' step, info related to test-002)

Related PR: https://github.com/tsduck/tsduck-test/pull/29
