### PR TITLE
Fixed use-of-uninitialized-value related to init of struct stat

### DIFF
--- a/src/libtsduck/base/system/tsFileUtils.cpp
+++ b/src/libtsduck/base/system/tsFileUtils.cpp
@@ -320,10 +320,10 @@ fs::path ts::TempFile(const UString& suffix)
 ts::Time ts::GetFileModificationTimeUTC(const UString& path)
 {
 #if defined(TS_WINDOWS)
-    ::WIN32_FILE_ATTRIBUTE_DATA info;
+    ::WIN32_FILE_ATTRIBUTE_DATA info {};
     return ::GetFileAttributesExW(path.wc_str(), ::GetFileExInfoStandard, &info) == 0 ? Time::Epoch : Time::Win32FileTimeToUTC(info.ftLastWriteTime);
 #else
-    struct stat st;
+    struct stat st {};
     return ::stat(path.toUTF8().c_str(), &st) < 0 ? Time::Epoch : Time::UnixTimeToUTC(st.st_mtime);
 #endif
 }

--- a/src/libtsduck/dtv/transport/tsTSFile.cpp
+++ b/src/libtsduck/dtv/transport/tsTSFile.cpp
@@ -352,7 +352,7 @@ bool ts::TSFile::openInternal(bool reopen, Report& report)
     }
 
     // Check if this is a regular file.
-    struct stat st;
+    struct stat st {};
     if (::fstat(_fd, &st) < 0) {
         report.log(_severity, u"cannot stat input file %s: %s", {getDisplayFileName(), SysErrorCodeMessage()});
         if (!_std_inout) {


### PR DESCRIPTION
This potential issue was found by MemorySanitizer (msan). Whether the actual problem occurs depends on the compiler, OS, and other factors.

msan output related to this fix:

~~~
$ ./tsp
==432620==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7fcfde24e8ac in ts::TSFile::seekCheck(ts::Report&) libtsduck/dtv/transport/tsTSFile.cpp:411:18
    #1 0x7fcfde24a9c6 in ts::TSFile::openInternal(bool, ts::Report&) libtsduck/dtv/transport/tsTSFile.cpp:366:10
    #2 0x7fcfde24d542 in ts::TSFile::openRead(std::__1::__fs::filesystem::path const&, unsigned long, unsigned long, ts::Report&, ts::TSPacketFormat) libtsduck/dtv/transport/tsTSFile.cpp:151:12
    #3 0x7fcfde25980d in ts::TSFileInputArgs::openFile(unsigned long, unsigned long, ts::Report&) libtsduck/dtv/transport/tsTSFileInputArgs.cpp:149:31
    #4 0x7fcfde259fbd in ts::TSFileInputArgs::open(ts::Report&) libtsduck/dtv/transport/tsTSFileInputArgs.cpp:187:14
    #5 0x7fcfdd91fc44 in ts::FileInputPlugin::start() libtsduck/plugins/plugins/tsFileInputPlugin.cpp:37:18
    #6 0x7fcfde2b3bd2 in ts::TSProcessor::start(ts::TSProcessorArgs const&) libtsduck/plugins/apps/tsTSProcessor.cpp:179:30
    #7 0x555c0ab44103 in MainCode(int, char**) tstools/tsp.cpp:147:17
    #8 0x7fcfddc45a52 in MainWrapper(int (*)(int, char**), int, char**) libtsduck/base/app/tsMain.cpp:35:16
    #9 0x555c0ab4282d in main tstools/tsp.cpp:22:1
    ...

  Uninitialized value was stored to memory at
    #0 0x7fcfde24c6cb in ts::TSFile::openInternal(bool, ts::Report&) libtsduck/dtv/transport/tsTSFile.cpp:363:14
    #1 0x7fcfde24d542 in ts::TSFile::openRead(std::__1::__fs::filesystem::path const&, unsigned long, unsigned long, ts::Report&, ts::TSPacketFormat) libtsduck/dtv/transport/tsTSFile.cpp:151:12
    #2 0x7fcfde25980d in ts::TSFileInputArgs::openFile(unsigned long, unsigned long, ts::Report&) libtsduck/dtv/transport/tsTSFileInputArgs.cpp:149:31
    #3 0x7fcfde259fbd in ts::TSFileInputArgs::open(ts::Report&) libtsduck/dtv/transport/tsTSFileInputArgs.cpp:187:14
    #4 0x7fcfdd91fc44 in ts::FileInputPlugin::start() libtsduck/plugins/plugins/tsFileInputPlugin.cpp:37:18
    #5 0x7fcfde2b3bd2 in ts::TSProcessor::start(ts::TSProcessorArgs const&) libtsduck/plugins/apps/tsTSProcessor.cpp:179:30
    #6 0x555c0ab44103 in MainCode(int, char**) tstools/tsp.cpp:147:17
    ...

  Uninitialized value was created by an allocation of 'st' in the stack frame of function '_ZN2ts6TSFile12openInternalEbRNS_6ReportE'
    #0 0x7fcfde24a0b0 in ts::TSFile::openInternal(bool, ts::Report&) libtsduck/dtv/transport/tsTSFile.cpp:196

SUMMARY: MemorySanitizer: use-of-uninitialized-value libtsduck/dtv/transport/tsTSFile.cpp:411:18 in ts::TSFile::seekCheck(ts::Report&)
~~~

#### Related issue (if any):
no related issue

#### Affected components:
TSDuck library

#### Brief description of the proposed changes:
This patch properly inits st (stat) structure
