### PR TITLE
Fixed undefined behaviour in pcrcopy plugin that cause real issue with label processing

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -521,6 +521,16 @@ else
     LDFLAGS_ASAN =
 endif
 
+# Compilation flags for code sanitizing using UndefinedBehaviorSanitizer with default optimization.
+
+ifneq ($(UBSAN),)
+    CXXFLAGS_UBSAN = -fsanitize=undefined -fno-sanitize=unsigned-integer-overflow -fno-sanitize=alignment -g3
+    LDFLAGS_UBSAN = -fsanitize=undefined -fno-sanitize=unsigned-integer-overflow -fno-sanitize=alignment -g3
+else
+    CXXFLAGS_UBSAN =
+    LDFLAGS_UBSAN =
+endif
+
 # Compilation flags for code coverage using gcov.
 
 ifneq ($(GCOV),)
@@ -553,10 +563,10 @@ LDLIBS += -lstdc++ -lpthread $(if $(MACOS)$(OPENBSD),,-lrt) -lm
 # Global compilation flags.
 # Additional flags can be passed on the "make" command line using xxFLAGS_EXTRA.
 
-CXXFLAGS = $(CXXFLAGS_DEBUG) $(CXXFLAGS_M32) $(CXXFLAGS_ASAN) $(CXXFLAGS_GCOV) $(CXXFLAGS_GPROF) $(CXXFLAGS_WARNINGS) \
+CXXFLAGS = $(CXXFLAGS_DEBUG) $(CXXFLAGS_M32) $(CXXFLAGS_ASAN) $(CXXFLAGS_UBSAN) $(CXXFLAGS_GCOV) $(CXXFLAGS_GPROF) $(CXXFLAGS_WARNINGS) \
            $(CXXFLAGS_SECURITY) $(CXXFLAGS_INCLUDES) $(CXXFLAGS_TARGET) $(CXXFLAGS_FPIC) $(CXXFLAGS_STANDARD) \
            $(CXXFLAGS_CROSS) $(CXXFLAGS_PTHREAD) $(CXXFLAGS_EXTRA)
-LDFLAGS  = $(LDFLAGS_DEBUG) $(LDFLAGS_M32) $(LDFLAGS_ASAN) $(LDFLAGS_GCOV) $(LDFLAGS_GPROF) $(CXXFLAGS_TARGET) \
+LDFLAGS  = $(LDFLAGS_DEBUG) $(LDFLAGS_M32) $(LDFLAGS_ASAN) $(LDFLAGS_UBSAN) $(LDFLAGS_GCOV) $(LDFLAGS_GPROF) $(CXXFLAGS_TARGET) \
            $(LDFLAGS_CROSS) $(LDFLAGS_PTHREAD) $(LDFLAGS_EXTRA)
 ARFLAGS  = rc$(if $(MACOS),,U) $(ARFLAGS_EXTRA)
 

--- a/src/tsplugins/tsplugin_pcrcopy.cpp
+++ b/src/tsplugins/tsplugin_pcrcopy.cpp
@@ -166,13 +166,13 @@ ts::ProcessorPlugin::Status ts::PCRCopyPlugin::processPacket(TSPacket& pkt, TSPa
     const PID pid = pkt.getPID();
 
     // Process PID switching according to labels.
-    if (pkt_data.hasLabel(_ref_label) && pid != _ref_pid && pid != PID_NULL) {
+    if ((_ref_label != (TSPacketLabelSet::MAX + 1)) && pkt_data.hasLabel(_ref_label) && pid != _ref_pid && pid != PID_NULL) {
         // Switch to a new reference PID.
         tsp->verbose(u"using PID 0x%X (%<d) as PCR reference", {pid});
         _ref_pid = pid;
         _ref_pcr = INVALID_PCR;
     }
-    if (pkt_data.hasLabel(_target_label) && pid != _target_pid && pid != PID_NULL) {
+    if ((_target_label != (TSPacketLabelSet::MAX + 1)) && pkt_data.hasLabel(_target_label) && pid != _target_pid && pid != PID_NULL) {
         // Switch to a new target PID.
         tsp->verbose(u"using PID 0x%X (%<d) to insert copied PCR", {pid});
         _target_pid = pid;


### PR DESCRIPTION
#### Related issue (if any):
no related issue

#### Affected components:
pcrcopy plugin

#### Brief description of the proposed changes:
If --reference-label is not set by user, then _ref_label sets to 32 (TSPacketLabelSet::MAX+1)
by ts::PCRCopyPlugin::getOptions().
ts::PCRCopyPlugin::processPacket() calls pkt_data.hasLabel(_ref_label) that calls
CompactBitSet::test() that uses 'int_t(1)<<pos' code, where int_t is uint32_t and pos=32
1<<32 is undefined by C++ standard for 32-bit unsinged integer. In real world 1<<32 usually
equals to 1 so it means that pkt_data.hasLabel(32) is equal to pkt_data.hasLabel(0)

Real issue can be caused by the following command (reproduces on macos arm64 clang-15 and
linux x86_64 gcc-12):

~~~
% tsp --verbose -I file ../tsduck-test/input/test-092.ts -P filter -p 0x140 --set-label 0 -P pcrcopy -r 0x78 -t 0x82 -O drop
* file: initial input bitrate is 24,047,795 b/s
* pcrcopy: using PID 0x0140 (320) as PCR reference
* pcrcopy: using PID 0x0140 (320) to insert copied PCR
~~~

In this example, user asks pcrcopy plugin to copy PCR values from pid 0x78 to 0x82, but tsduck copies from
0x140 to 0x140 because label 0 was set by filter plugin.

Minimal example to check the behaviour on different systems and compilers:
~~~
% cat undef.cpp
#include <iostream>
#include <sstream>

int main(int argc, char *argv[]) {
    std::cout << (uint32_t(1) << size_t(32)) << std::endl;
    std::stringstream argv1(argv[1]);
    size_t exp;
    argv1 >> exp;
    std::cout << (uint32_t(1) << exp) << std::endl;
    return 0;
}
~~~

~~~
% clang++ undef.cpp
% ./a.out 32 # on macos arm64, clang-15
1796978288
1
% ./a.out 32 # on macos arm64, second try
1842411120
1
~~~

~~~
$ g++ undef.cpp
$ ./a.out 32 # on linux x86_64, gcc-12
0
1
$ ./a.out 32 # on linux x86_64, second try
0
1
~~~

~~~
This issue was found during tsduck-test/test-093 with UBSAN enabled:
    > libtsduck/base/types/tsCompactBitSet.h:214:66: runtime error: shift exponent 32 is too large for 32-bit type 'int_t' (aka 'unsigned int')
    >     #0 0x1048eb140 in ts::PCRCopyPlugin::processPacket(ts::TSPacket&, ts::TSPacketMetadata&) tsplugin_pcrcopy.cpp:169
    >     #1 0x1078bf8f4 in ts::tsp::ProcessorExecutor::processIndividualPackets() tstspProcessorExecutor.cpp:173
    >     #2 0x1078becf0 in ts::tsp::ProcessorExecutor::main() tstspProcessorExecutor.cpp:74
    >     #3 0x10774a3d0 in ts::Thread::mainWrapper() tsThread.cpp:345
    >     #4 0x107749f98 in ts::Thread::ThreadProc(void*) tsThread.cpp:389
    >     #5 0x18b9a5030 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x7030)
    >     #6 0x18b99fe38 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1e38)
    >
    > SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior libtsduck/base/types/tsCompactBitSet.h:214:66 in
~~~