### PR TITLE
Added 64 bit RISC-V platform support

### DIFF
--- a/src/libtsduck/base/cpp/tsPlatform.h
+++ b/src/libtsduck/base/cpp/tsPlatform.h
@@ -365,6 +365,10 @@
     //! Defined when the target processor architecture is MIPS architecture.
     //!
     #define TS_MIPS
+    //!
+    //! Defined when the target processor architecture is 64-bit RISC-V.
+    //!
+    #define TS_RISCV64
 
 #elif defined(__i386__) || defined(TS_I386) || defined(_M_IX86)
     #if !defined(TS_I386)
@@ -444,6 +448,13 @@
     #if !defined(TS_ADDRESS_BITS)
         #define TS_ADDRESS_BITS 32
     #endif
+#elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 64)
+    #if !defined(TS_RISCV64)
+        #define TS_RISCV64 1
+    #endif
+    #if !defined(TS_ADDRESS_BITS)
+        #define TS_ADDRESS_BITS 64
+    #endif
 #else
     #error "New unknown processor, please update tsPlatform.h"
 #endif
@@ -462,7 +473,7 @@
 
 // Byte order
 
-#if (defined(TS_I386) || defined(TS_X86_64) || defined(TS_IA64) || defined(TS_ALPHA)) && !defined(TS_LITTLE_ENDIAN)
+#if (defined(TS_I386) || defined(TS_X86_64) || defined(TS_IA64) || defined(TS_ALPHA) || defined(TS_RISCV64)) && !defined(TS_LITTLE_ENDIAN)
     #define TS_LITTLE_ENDIAN 1
 #elif (defined(TS_SPARC) || defined(TS_POWERPC) || defined(TS_POWERPC64)) && !defined(TS_BIG_ENDIAN)
     #define TS_BIG_ENDIAN 1

--- a/src/libtsduck/base/system/tsSysInfo.cpp
+++ b/src/libtsduck/base/system/tsSysInfo.cpp
@@ -86,6 +86,8 @@ ts::SysInfo::SysInfo() :
     _cpuName(u"PowerPC-64"),
 #elif defined(TS_POWERPC)
     _cpuName(u"PowerPC"),
+#elif defined(TS_RISCV64)
+    _cpuName(u"RISCV-64"),
 #else
     _cpuName(u"unknown CPU"),
 #endif


### PR DESCRIPTION
utest and tsduck-test tests are passed (except test-019 (dektec related))

verified on ubuntu 23.10, gcc 13.2

$ tsp --version=all
tsp: TSDuck - The MPEG Transport Stream Toolkit - version 3.37-3602 Built Jan 13 2024 - 18:28:07
Using GCC 13.2.0, C++ std 2017.03
System: Ubuntu (Ubuntu 23.10), on RISCV-64, 64-bit, little-endian, page size: 4096 bytes Acceleration: CRC32: no, AES: no, SHA-1: no, SHA-256: no, SHA-512: no Bitrate: 64-bit floating-point value
Dektec: This version of TSDuck was compiled without Dektec support VATek: libvatek version 3.10
Web library: libcurl: 8.2.1, ssl: OpenSSL/3.0.10, libz: 1.2.13 SRT library: libsrt version 1.5.2
RIST library: librist version 0.2.7, API version 4.2.0

#### Related issue (if any):
no related issue

#### Affected components:
TSDuck library

#### Brief description of the proposed changes:
RISC-V 64 bit support (only formal things, no real changes)