### PR TITLE
Added S390X platform support

### DIFF
--- a/src/libtsduck/base/cpp/tsPlatform.h
+++ b/src/libtsduck/base/cpp/tsPlatform.h
@@ -369,6 +369,10 @@
     //! Defined when the target processor architecture is 64-bit RISC-V.
     //!
     #define TS_RISCV64
+    //!
+    //! Defined when the target processor architecture is S390X.
+    //!
+    #define TS_S390X
 
 #elif defined(__i386__) || defined(TS_I386) || defined(_M_IX86)
     #if !defined(TS_I386)
@@ -455,6 +459,13 @@
     #if !defined(TS_ADDRESS_BITS)
         #define TS_ADDRESS_BITS 64
     #endif
+#elif defined(__s390x__)
+    #if !defined(TS_S390X)
+        #define TS_S390X 1
+    #endif
+    #if !defined(TS_ADDRESS_BITS)
+        #define TS_ADDRESS_BITS 64
+    #endif
 #else
     #error "New unknown processor, please update tsPlatform.h"
 #endif
@@ -475,7 +486,7 @@
 
 #if (defined(TS_I386) || defined(TS_X86_64) || defined(TS_IA64) || defined(TS_ALPHA) || defined(TS_RISCV64)) && !defined(TS_LITTLE_ENDIAN)
     #define TS_LITTLE_ENDIAN 1
-#elif (defined(TS_SPARC) || defined(TS_POWERPC) || defined(TS_POWERPC64)) && !defined(TS_BIG_ENDIAN)
+#elif (defined(TS_SPARC) || defined(TS_POWERPC) || defined(TS_POWERPC64) || defined(TS_S390X)) && !defined(TS_BIG_ENDIAN)
     #define TS_BIG_ENDIAN 1
 #endif
 

--- a/src/libtsduck/base/system/tsSysInfo.cpp
+++ b/src/libtsduck/base/system/tsSysInfo.cpp
@@ -88,6 +88,8 @@ ts::SysInfo::SysInfo() :
     _cpuName(u"PowerPC"),
 #elif defined(TS_RISCV64)
     _cpuName(u"RISCV-64"),
+#elif defined(TS_S390X)
+    _cpuName(u"S390X"),
 #else
     _cpuName(u"unknown CPU"),
 #endif


### PR DESCRIPTION
utest and tsduck-test tests are passed (if compiler is clang-16)

Verified on Ubuntu 23.10, clang 16.0.6 (make LLVM=1) Currently there are some issues if compiler is gcc-13 (more info #1418).

Currently S390X is the only supported big-endian architecture by generic Linux distros so it might be useful to test tsduck on BE platform.

There are several ways how to develop for s390x without buying IBM mainframes: https://docs.gitlab.com/omnibus/development/s390x.html

~~~
$ tsp --version=all
tsp: TSDuck - The MPEG Transport Stream Toolkit - version 3.37-3606 Built Jan 15 2024 - 09:45:54
Using Clang 16.0.6 (15), C++ std 2017.03
System: Ubuntu (Ubuntu 23.10), on S390X, 64-bit, big-endian, page size: 4096 bytes Acceleration: CRC32: no, AES: no, SHA-1: no, SHA-256: no, SHA-512: no Bitrate: 64-bit floating-point value
Dektec: This version of TSDuck was compiled without Dektec support VATek: libvatek version 3.10
Web library: libcurl: 8.2.1, ssl: OpenSSL/3.0.10, libz: 1.2.13 SRT library: libsrt version 1.5.2
RIST library: librist version 0.2.7, API version 4.2.0
~~~

#### Related issue (if any):
#1418 

#### Affected components:
TSDuck library

#### Brief description of the proposed changes:
Added S390X platform support (only formal things, no real changes)