### PR TITLE
indent the target reqion information for a siganlled service

### DIFF
--- a/src/libtsduck/dtv/descriptors/dvb/tsDVBServiceProminenceDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDVBServiceProminenceDescriptor.cpp
@@ -175,12 +175,12 @@ void ts::DVBServiceProminenceDescriptor::DisplayDescriptor(TablesDisplay& disp, 
                     const uint8_t region_depth = buf.getBits<uint8_t>(2);
                     bool drawn = false;
                     if (country_code_flag && buf.canReadBytes(3)) {
-                        disp << margin << "Country: " << buf.getLanguageCode();
+                        disp << margin << " Country: " << buf.getLanguageCode();
                         drawn = true;
                     }
                     if (region_depth >= 1 && buf.canReadBytes(1)) {
                         if (!drawn) {
-                            disp << margin << "P";
+                            disp << margin << " P";
                             drawn = true;
                         }
                         else {
@@ -189,7 +189,7 @@ void ts::DVBServiceProminenceDescriptor::DisplayDescriptor(TablesDisplay& disp, 
                         disp << "rimary region: " << int(buf.getUInt8());
                         if (region_depth >= 2 && buf.canReadBytes(1)) {
                             if (!drawn) {
-                                disp << margin << "S";
+                                disp << margin << " S";
                                 drawn = true;
                             }
                             else {
@@ -198,7 +198,7 @@ void ts::DVBServiceProminenceDescriptor::DisplayDescriptor(TablesDisplay& disp, 
                             disp << "econdary region: " << int(buf.getUInt8());
                             if (region_depth >= 3 && buf.canReadBytes(2)) {
                                 if (!drawn) {
-                                    disp << margin << "T";
+                                    disp << margin << " T";
                                     drawn = true;
                                 }
                                 else {


### PR DESCRIPTION
Small update to the printout of the DVB Service Prominence Descriptor to more clearly indicate that target regions are part of eash service.