### PR TITLE
Add the HDR Vivid vfrom UHD World Association (see T/UWA 005)

### DIFF
--- a/src/libtsduck/dtv/descriptors/dvb/tsComponentDescriptor.names
+++ b/src/libtsduck/dtv/descriptors/dvb/tsComponentDescriptor.names
@@ -156,6 +156,7 @@ Bits = 16
 0xBF07 = ETSI TS 103 433 (SL-HDR2) DMI
 0xBF08 = SMPTE ST 2094-40 (HDR10+) DMI
 0xBF09 = PQ10 HDR
+0xBF0A = T/UWA 005-1 (HDR Vivid) DMI
 
 [component_descriptor.component_type.japan]
 # Japanese version.

--- a/src/libtsduck/dtv/descriptors/uwa/tsUWAVideoStreamDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/uwa/tsUWAVideoStreamDescriptor.cpp
@@ -1,0 +1,140 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2024, Paul Higgs
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsUWAVideoStreamDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+#include "tsAlgorithm.h"
+
+#define MY_XML_NAME u"CUVV_video_stream_descriptor"
+#define MY_CLASS    ts::UWAVideoStreamDescriptor
+#define MY_DID      ts::DID_CUVV_HDR
+#define MY_PDS      ts::PDS_CUVV
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::Private(MY_DID, MY_PDS), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+
+//----------------------------------------------------------------------------
+// Enumerations, names for values
+//----------------------------------------------------------------------------
+
+const ts::Enumeration ts::UWAVideoStreamDescriptor::VersionNumbers({
+    {u"1.0", 0x0005},
+    {u"2.0", 0x0006},
+    {u"3.0", 0x0007},
+    {u"4.0", 0x0008},
+
+});
+
+//----------------------------------------------------------------------------
+// Constructors
+//----------------------------------------------------------------------------
+
+ts::UWAVideoStreamDescriptor::UWAVideoStreamDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, MY_PDS)
+{
+}
+
+void ts::UWAVideoStreamDescriptor::clearContent()
+{
+    cuvv_tag = 0;
+    cuva_version_map = 0;
+    terminal_provide_code = 0;
+    terminal_provide_oriented_code = 0;
+}
+
+ts::UWAVideoStreamDescriptor::UWAVideoStreamDescriptor(DuckContext& duck, const Descriptor& desc) :
+    UWAVideoStreamDescriptor()
+{
+    deserialize(duck, desc);
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::UWAVideoStreamDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putUInt32(cuvv_tag);
+    buf.putUInt16(cuva_version_map);
+    buf.putUInt16(terminal_provide_code);
+    buf.putInt16(int16_t(terminal_provide_oriented_code));
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::UWAVideoStreamDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    cuvv_tag = buf.getUInt32();
+    cuva_version_map = buf.getUInt16();
+    terminal_provide_code = buf.getUInt16();
+    terminal_provide_oriented_code = buf.getInt16();
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::UWAVideoStreamDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(10)) {
+        disp << margin << "CUVV Tag: " << DataName(MY_XML_NAME, u"CUVV_tag", buf.getUInt32(), NamesFlags::VALUE | NamesFlags::HEXA);
+        uint16_t _version_map = buf.getUInt16();
+        disp << ", provider code: " << UString::Format(u"0x%x", buf.getUInt16());
+        disp << ", provider oriented code: " << DataName(MY_XML_NAME, u"terminal_provide_oriented_code", buf.getInt16(), NamesFlags::VALUE | NamesFlags::HEXA) << std::endl;
+
+        std::vector<int8_t> versions;
+        for (uint8_t i = 0; i < 16; i++) {
+            if (_version_map & (1 << i)) {
+                versions.push_back(i + 1);
+            }
+        }
+        if (versions.empty()) {
+            disp << margin << "No versions specified" << std::endl;
+        }
+        else {
+            disp.displayVector(u"Verson Map:", versions, margin, true, 8);
+        }
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::UWAVideoStreamDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"cuvv_tag", cuvv_tag, true);
+    root->setIntAttribute(u"cuva_version_map", cuva_version_map, true);
+    root->setIntAttribute(u"terminal_provide_code", terminal_provide_code, true);
+    root->setEnumAttribute(VersionNumbers, u"terminal_provide_oriented_code", terminal_provide_oriented_code);
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::UWAVideoStreamDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getIntAttribute(cuvv_tag, u"cuvv_tag", true, ts::PDS_CUVV, ts::PDS_CUVV, ts::PDS_CUVV) &&
+           element->getIntAttribute(cuva_version_map, u"cuva_version_map", true) &&
+           element->getIntAttribute(terminal_provide_code, u"terminal_provide_code", true, 0x0004, 0x0004, 0x0004) &&
+           element->getEnumAttribute(terminal_provide_oriented_code, VersionNumbers, u"terminal_provide_oriented_code", true, 0x0005);
+}

--- a/src/libtsduck/dtv/descriptors/uwa/tsUWAVideoStreamDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/uwa/tsUWAVideoStreamDescriptor.h
@@ -1,0 +1,61 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2024, Paul Higgs
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of an CUVV_video_stream_descriptor
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+#include "tsByteBlock.h"
+
+namespace ts {
+    //!
+    //! Representation of an CUVV_video_stream_descriptor.
+    //!
+    //! @see T/UWA 005-2.1.
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL UWAVideoStreamDescriptor : public AbstractDescriptor
+    {
+    public:
+        // Public members:
+        uint32_t  cuvv_tag = 0;
+        uint16_t  cuva_version_map = 0;
+        uint16_t  terminal_provide_code = 0;
+        int       terminal_provide_oriented_code = 0;
+
+        //!
+        //! Default constructor.
+        //!
+        UWAVideoStreamDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        UWAVideoStreamDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    private:
+        // Enumerations for XML.
+        static const Enumeration VersionNumbers;
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}

--- a/src/libtsduck/dtv/descriptors/uwa/tsUWAVideoStreamDescriptor.names
+++ b/src/libtsduck/dtv/descriptors/uwa/tsUWAVideoStreamDescriptor.names
@@ -1,0 +1,11 @@
+[CUVV_video_stream_descriptor.CUVV_tag]
+Bits = 32
+0x63757676 = cuvv
+
+[CUVV_video_stream_descriptor.terminal_provide_oriented_code]
+Bits = 16
+# see Table 5 of T/UWA 005-2.1
+0x0005 = 1.0
+0x0006 = 2.0
+0x0007 = 3.0
+0x0008 = 4.0

--- a/src/libtsduck/dtv/descriptors/uwa/tsUWAVideoStreamDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/uwa/tsUWAVideoStreamDescriptor.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <CUVV_video_stream_descriptor
+      cuvv_tag="uint32, required to be 0x63757676"
+      cuva_version_map="uint16, required"
+      terminal_provide_code="uint16, required to be 0x0004"
+      terminal_provide_oriented_code="1.0|2.0|3.0|4.0, required"/>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/signalization/tsPSI.cpp
+++ b/src/libtsduck/dtv/signalization/tsPSI.cpp
@@ -38,6 +38,7 @@ const ts::Enumeration ts::PrivateDataSpecifierEnum({
     {u"Australia", ts::PDS_AUSTRALIA},
     {u"AVS",       ts::PDS_AVS},
     {u"AOM",       ts::PDS_AOM},
+    {u"cuvv",      ts::PDS_CUVV},
 });
 
 

--- a/src/libtsduck/dtv/signalization/tsPSI.h
+++ b/src/libtsduck/dtv/signalization/tsPSI.h
@@ -22,6 +22,7 @@ namespace ts {
     //
     using TID = uint8_t ;  //!< Table identifier.
     using DID = uint8_t ;  //!< Descriptor identifier.
+    using DID = uint8_t ;  //!< Descriptor identifier.
     using PDS = uint32_t;  //!< Private data specifier.
 
     //!
@@ -317,6 +318,7 @@ namespace ts {
         PDS_ATSC      = 0x41545343, //!< Fake private data specifier for ATSC descriptors (value is "ATSC" in ASCII).
         PDS_AVS       = 0x41565356, //!< Private data specifier for AVS Working Group of China (value is "AVSV" in ASCII).
         PDS_ISDB      = 0x49534442, //!< Fake private data specifier for ISDB descriptors (value is "ISDB" in ASCII).
+        PDS_CUVV      = 0x63757676, //!< Private data specifier for UHD World Association (value is "cuvv" in ASCII).
         PDS_NULL      = 0xFFFFFFFF, //!< An invalid private data specifier, can be used as placeholder.
     };
 
@@ -659,6 +661,10 @@ namespace ts {
         // Valid in DVB context after PDS_AVS private_data_specifier
 
         DID_AVS3_VIDEO          = 0xD1, //!< DID for AVS3 video descriptor, as defined in T/AI 109.6
+
+        // Valid in DVB context after PDS_CUVV private_data_specifier
+
+        DID_CUVV_HDR            = 0xF3,  //!< DID for UWA HDR Vivid video descriptor, as defined in T/UWA 005.2-1
 
         // Valid in DVB context after PDS_AOM private_data_specifier
 

--- a/src/libtsduck/dtv/signalization/tsPSI.h
+++ b/src/libtsduck/dtv/signalization/tsPSI.h
@@ -22,7 +22,6 @@ namespace ts {
     //
     using TID = uint8_t ;  //!< Table identifier.
     using DID = uint8_t ;  //!< Descriptor identifier.
-    using DID = uint8_t ;  //!< Descriptor identifier.
     using PDS = uint32_t;  //!< Private data specifier.
 
     //!

--- a/src/libtsduck/dtv/signalization/tsPSI.names
+++ b/src/libtsduck/dtv/signalization/tsPSI.names
@@ -770,6 +770,10 @@ Bits = 8
 0x49534442_FC = ISDB Emergency Information
 0x49534442_FD = ISDB Data Component
 0x49534442_FE = ISDB System Management
+# With PDS for UWA.
+# Descriptors are defined by the UHD World Association.
+0x63757676_F3 = HDR Vivid Video
+
 
 [MPEGExtendedDescriptorId]
 Bits = 8


### PR DESCRIPTION
#### Brief description of the proposed changes:

T/UWA 005-2.1 is the signalling specification defining different carriage mechanisms for HDR Vivid dynamic metadata. This PR adds support for the descriptor which provides HDR Vivid version information and the value for signalling HDR Vivid in a DVB Component descriptor.
