### PR TITLE
Ensure python correctly interprets path specifier

### DIFF
--- a/scripts/build-project-files.py
+++ b/scripts/build-project-files.py
@@ -140,7 +140,7 @@ def build_ms_files(names, srcdir, props):
             f.write('    <Import Project="msvc-common-begin.props"/>\n')
             f.write('  </ImportGroup>\n')
             f.write('  <ItemGroup>\n')
-            f.write('    <ClCompile Include="..\..\src\%s\%s.cpp"/>\n' % (srcdir, name))
+            f.write('    <ClCompile Include="..\\..\\src\\%s\\%s.cpp"/>\n' % (srcdir, name))
             f.write('  </ItemGroup>\n')
             f.write('  <PropertyGroup Label="Globals">\n')
             f.write('    <ProjectGuid>{%s}</ProjectGuid>\n' % (guid))


### PR DESCRIPTION
It appears that recent versions of python, i.e. 3.12.3, are interpreting "\.." in the path as an escape character. 

See https://stackoverflow.com/questions/52335970/how-to-fix-syntaxwarning-invalid-escape-sequence-in-python