### PR TITLE
Confirmed stream_type values for VVC

### DIFF
--- a/src/libtsduck/dtv/signalization/tsPSI.cpp
+++ b/src/libtsduck/dtv/signalization/tsPSI.cpp
@@ -116,8 +116,6 @@ bool ts::StreamTypeIsHEVC(uint8_t st)
 
 bool ts::StreamTypeIsVVC(uint8_t st)
 {
-    // Warning: at this time, the stream types for VVC / H.266 are still unclear.
-    // Be sure to verity this on further versions of the ISO 13818-1 standard.
     return st == ST_VVC_VIDEO        ||
            st == ST_VVC_VIDEO_SUBSET;
 }


### PR DESCRIPTION
Confirmed the stream_type values for VVC according to ISO/IEC 13818-1:2023 (9th edition - https://www.iso.org/standard/87619.html) and H.222.0 v9 (08/23 - https://www.itu.int/itu-t/recommendations/rec.aspx?rec=15655&lang=en)

#### Brief description of the proposed changes:
Remove the health warding on non-confirmed values for `ST_VVC_VIDEO` and `ST_VVC_VIDEO_SUBSET`
