### PR TITLE
Update the DVB AAC descriptor to be more aligned with EN 300 468

### DIFF
--- a/src/libtsduck/dtv/descriptors/dvb/tsAACDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsAACDescriptor.h
@@ -26,7 +26,7 @@ namespace ts {
     public:
         // Public members:
         uint8_t                profile_and_level = 0;  //!< See ETSI EN 300 468, H.2.1.
-        bool                   SAOC_DE = false;        //!< See ETSI EN 300 468, H.2.1.
+        std::optional<bool>    SAOC_DE {};             //!< See ETSI EN 300 468, H.2.1.
         std::optional<uint8_t> AAC_type {};            //!< See ETSI EN 300 468, H.2.1.
         ByteBlock              additional_info {};     //!< See ETSI EN 300 468, H.2.1.
 

--- a/src/libtsduck/dtv/descriptors/dvb/tsAACDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsAACDescriptor.xml
@@ -4,7 +4,7 @@
 
     <AAC_descriptor
         profile_and_level="uint8, required"
-        SAOC_DE="bool, default=false"
+        SAOC_DE="bool, optional, default=false"
         AAC_type="uint8, optional">
       <additional_info>
         Hexadecimal content

--- a/src/libtsduck/dtv/descriptors/dvb/tsAACDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsAACDescriptor.xml
@@ -4,7 +4,7 @@
 
     <AAC_descriptor
         profile_and_level="uint8, required"
-        SAOC_DE="bool, optional, default=false"
+        SAOC_DE="bool, optional"
         AAC_type="uint8, optional">
       <additional_info>
         Hexadecimal content


### PR DESCRIPTION
#### Brief description of the proposed changes:

Updates the `AAC_descriptor` from [ETSI EN 300 468 v1.18.1](https://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.18.01_60/en_300468v011801p.pdf) which does not allow the `AAC_type` or `additional_info_byte`(s) to be specified unless the `SAOC_DE_flag` is present

````
Table H.1: AAC descriptor

+---------------------------------+---------+------------+
| Syntax                          | Number  | Identifier |
|                                 | of bits |            |
+---------------------------------+---------+------------+
|AAC_descriptor() {               |         |            |
|   descriptor_tag                |    8    | uimsbf     |
|   descriptor_length             |    8    | uimsbf     |
|   profile_and_level             |    8    | uimsbf     |
|   if (descriptor_length > 1) {  |         |            |
|      AAC_type_flag              |    1    | bslbf      |
|      SAOC_DE_flag               |    1    | bslbf      |
|      reserved_zero_future_use   |    6    | bslbf      |
|      if (AAC_type_flag == 0b1   |         |            |
|         AAC_type                |    8    | uimsbf     |
|      }                          |         |            |
|      for (i=0;i<N;i++) {        |         |            |
|         additional_info_byte    |    8    | uimsbf     |
|      }                          |         |            |
|   }                             |         |            |
|}                                |         |            |
+---------------------------------+---------+------------+
````

