### PR TITLE
use std::optional for optional values in Supplmentary Audio Descriptor

### DIFF
--- a/src/libtsduck/base/xml/tsxmlElement.h
+++ b/src/libtsduck/base/xml/tsxmlElement.h
@@ -268,6 +268,18 @@ namespace ts {
             void setAttribute(const UString& name, const UString& value, bool onlyIfNotEmpty = false);
 
             //!
+            //! Set an optional attribute to a node.
+            //! @param [in] name Attribute name.
+            //! @param [in] value Attribute value.
+            //!
+            void setOptionalAttribute(const UString& name, const std::optional<UString>& value)
+            {
+                if (value.has_value()) {
+                    setAttribute(name, value.value());
+                }
+            }
+
+			//!
             //! Set a bool attribute to a node.
             //! @param [in] name Attribute name.
             //! @param [in] value Attribute value.

--- a/src/libtsduck/dtv/descriptors/dvb/tsSupplementaryAudioDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsSupplementaryAudioDescriptor.h
@@ -25,10 +25,10 @@ namespace ts {
     {
     public:
         // Public members:
-        uint8_t   mix_type = 0;                  //!< Complete or dependent stream, 1 bit.
-        uint8_t   editorial_classification = 0;  //!< Editorial classification, 5 bits.
-        UString   language_code {};              //!< ISO-639 language code, 3 characters or empty.
-        ByteBlock private_data {};               //!< Private data.
+        uint8_t                mix_type = 0;                  //!< Complete or dependent stream, 1 bit.
+        uint8_t                editorial_classification = 0;  //!< Editorial classification, 5 bits.
+        std::optional<UString> language_code {};              //!< ISO-639 language code, 3 characters.
+        ByteBlock              private_data {};               //!< Private data.
 
         //!
         //! Default constructor.

--- a/src/libtsduck/dtv/descriptors/dvb/tsSupplementaryAudioDescriptor.names
+++ b/src/libtsduck/dtv/descriptors/dvb/tsSupplementaryAudioDescriptor.names
@@ -5,8 +5,10 @@ Bits = 1
 
 [supplementary_audio_descriptor.Class]
 Bits = 5
-0 = main audio
-1 = audio description for the visually impaired
-2 = clean audio for the hearing impaired
-3 = spoken subtitles for the visually impaired
-4 = dependent parametric data stream
+0x00 = main audio
+0x01 = audio description for the visually impaired
+0x02 = clean audio for the hearing impaired
+0x03 = spoken subtitles for the visually impaired
+0x04 = dependent parametric data stream
+0x17 = unspecific supplementary audio for the general audience
+0x18-0x1f = user defined


### PR DESCRIPTION
Use std::optional for optional values in the Supplementary Audio Descriptor
