### PR TITLE
Added --pls-dvbapi to input plugin dvb

### DIFF
--- a/doc/user/plugins/dvb-input.adoc
+++ b/doc/user/plugins/dvb-input.adoc
@@ -236,7 +236,7 @@ Must be one of the following values:
 
 |DVB-S2
 |DVB-S2
-|`--fec-inner --frequency --isi --modulation --pilots --pls-code --pls-mode --polarity --roll-off
+|`--fec-inner --frequency --isi --modulation --pilots --pls-code --pls-mode --pls-dvbapi --polarity --roll-off
  --satellite-number --spectral-inversion --symbol-rate`
 
 |DVB-T
@@ -497,7 +497,7 @@ Used for DVB-S2 tuners only.
 
 [.optdoc]
 Specify the Input Stream Id (ISI) number to select, from 0 to 255.
-Used with multi-stream, see also options `--pls-code` and `--pls-mode`.
+Used with multi-stream, see also options `--pls-code`, `--pls-mode` and `--pls-dvbapi`.
 
 [.optdoc]
 The default is to keep the entire stream, without multi-stream selection.
@@ -591,6 +591,28 @@ Specify the Physical Layer Scrambling (PLS) mode.
 Used with multi-stream, see also option `--isi`.
 Must be one of `COMBO`, `GOLD`, `ROOT`.
 The default is `ROOT`.
+
+[.optdoc]
+*Warning*: this option is supported on Linux only.
+Currently, Windows provides no support for multi-stream.
+
+[.opt]
+*--pls-dvbapi*
+
+[.optdoc]
+Used for DVB-S2 tuners only.
+
+[.optdoc]
+When specified, the PLS code is set through the designated DVB API property
+instead of the older way to merge into the "stream id".
+Used with multi-stream, see also option `--isi`.
+
+[.optdoc]
+If this parameter is used, the PLS GOLD mode must be used.
+
+[.optdoc]
+The default is to merge the (left shifted) PLS code and PLS mode into the `DTV_STREAM_ID` property.
+DVB API later added the `DTV_SCRAMBLING_SEQUENCE_INDEX` property as standardized way to specify a PLS (GOLD) code.
 
 [.optdoc]
 *Warning*: this option is supported on Linux only.

--- a/src/libtsduck/dtv/broadcast/tsModulationArgs.h
+++ b/src/libtsduck/dtv/broadcast/tsModulationArgs.h
@@ -253,6 +253,13 @@ namespace ts {
         //!
         static constexpr PLSMode DEFAULT_PLS_MODE = PLS_ROOT;
         //!
+        //! Physical Layer Scrambling (PLS) DVB API property usage.
+        //! When specified to true, the PLS code is set through the designated DVB API property
+        //! instead of the older way to merge into the "stream id".
+        //! Applies to: DVB-S2.
+        //!
+        std::optional<bool> pls_dvbapi {};
+        //!
         //! Sound broadcasting.
         //! When specified to true, the reception is an ISDB-Tsb channel instead of an ISDB-T one.
         //! Applies to: ISDB-T.

--- a/src/libtsduck/dtv/linux/tsTunerDevice.cpp
+++ b/src/libtsduck/dtv/linux/tsTunerDevice.cpp
@@ -686,7 +686,6 @@ bool ts::TunerDevice::getCurrentTuning(ModulationArgs& params, bool reset_unknow
             params.pilots = Pilot(props.getByCommand(DTV_PILOT));
             params.roll_off = RollOff(props.getByCommand(DTV_ROLLOFF));
 
-            // With the Linux DVB API, all multistream selection info are passed in the "stream id".
 #if defined(DTV_STREAM_ID)
             const uint32_t id = props.getByCommand(DTV_STREAM_ID);
 #else
@@ -696,10 +695,12 @@ bool ts::TunerDevice::getCurrentTuning(ModulationArgs& params, bool reset_unknow
 
 #if defined(DTV_SCRAMBLING_SEQUENCE_INDEX)
             if (params.pls_dvbapi) {
+                // Recent Linux DVB API provides a designated property to set a PLS (GOLD) code
                 params.pls_code = props.getByCommand(DTV_SCRAMBLING_SEQUENCE_INDEX);
                 params.pls_mode = PLS_GOLD;
             } else {
 #endif
+                // With older Linux DVB API, all multistream selection info are passed in the "stream id".
                 params.pls_code = (id >> 8) & 0x0003FFFF;
                 params.pls_mode = PLSMode(id >> 26);
 #if defined(DTV_SCRAMBLING_SEQUENCE_INDEX)


### PR DESCRIPTION
#### Related issue (if any):
#1145

#### Affected components:
`dvb` input plugin

#### Brief description of the proposed changes:
Adds the ability to set the PLS (GOLD) code using designated DVB API property instead of the older way to merge into the "stream id". I successfully tested this with a Digital Devices SX8 and transponders on 5.0°W and 30.0°W which use PLS.

As the `CHANGELOG.TXT` also contains a version/commit number, I didn't modify it.

I require GOLD mode to be used, as DVB API does.

When `DTV_SCRAMBLING_SEQUENCE_INDEX` is not available, the code falls back to the older way. I'm not sure, if it would be better to fail instead during parameter check...