### PR TITLE
Add AVS audio descriptors from T/AI 109.7

### DIFF
--- a/src/libtsduck/base/cpp/tsPlatform.h
+++ b/src/libtsduck/base/cpp/tsPlatform.h
@@ -860,7 +860,6 @@ TS_MSC_NOWARNING(5045)  // Compiler will insert Spectre mitigation for memory lo
 #include <cstddef>
 #include <climits>
 #include <cmath>
-#include <variant>
 #include <fcntl.h>
 #if defined(TS_WINDOWS)
     #include <windows.h>

--- a/src/libtsduck/base/cpp/tsPlatform.h
+++ b/src/libtsduck/base/cpp/tsPlatform.h
@@ -858,6 +858,7 @@ TS_MSC_NOWARNING(5045)  // Compiler will insert Spectre mitigation for memory lo
 #include <cstddef>
 #include <climits>
 #include <cmath>
+#include <variant>
 #include <fcntl.h>
 #if defined(TS_WINDOWS)
     #include <windows.h>

--- a/src/libtsduck/dtv/codec/tsCodecType.cpp
+++ b/src/libtsduck/dtv/codec/tsCodecType.cpp
@@ -33,7 +33,8 @@ const ts::Enumeration ts::CodecTypeEnum({
     {u"DTS-HD",        ts::CodecType::DTSHD},
     {u"Teletext",      ts::CodecType::TELETEXT},
     {u"DVB Subtitles", ts::CodecType::DVB_SUBTITLES},
-    {u"AVS3",          ts::CodecType::AVS3},
+    {u"AVS3 Video",    ts::CodecType::AVS3_VIDEO},
+    {u"AVS3 Audio",    ts::CodecType::AVS3_AUDIO},
 });
 
 const ts::Enumeration ts::CodecTypeArgEnum({
@@ -69,7 +70,8 @@ const ts::Enumeration ts::CodecTypeArgEnum({
     {u"DTSHD",         ts::CodecType::DTSHD},
     {u"Teletext",      ts::CodecType::TELETEXT},
     {u"DVBSubtitles",  ts::CodecType::DVB_SUBTITLES},
-    {u"AVS3",          ts::CodecType::AVS3},
+    {u"AVS3Video",     ts::CodecType::AVS3_VIDEO},
+    {u"AVS3Audio",     ts::CodecType::AVS3_AUDIO},
 });
 
 
@@ -90,6 +92,7 @@ bool ts::CodecTypeIsAudio(CodecType ct)
         case CodecType::HEAAC:
         case CodecType::DTS:
         case CodecType::DTSHD:
+        case CodecType::AVS3_AUDIO:
             return true;
 
         case CodecType::UNDEFINED:
@@ -106,7 +109,7 @@ bool ts::CodecTypeIsAudio(CodecType ct)
         case CodecType::AV1:
         case CodecType::TELETEXT:
         case CodecType::DVB_SUBTITLES:
-        case CodecType::AVS3:
+        case CodecType::AVS3_VIDEO:
         default:
             return false;
     }
@@ -131,7 +134,7 @@ bool ts::CodecTypeIsVideo(CodecType ct)
         case CodecType::LCEVC:
         case CodecType::VP9:
         case CodecType::AV1:
-        case CodecType::AVS3:
+        case CodecType::AVS3_VIDEO:
             return true;
 
         case CodecType::UNDEFINED:
@@ -147,6 +150,7 @@ bool ts::CodecTypeIsVideo(CodecType ct)
         case CodecType::DTSHD:
         case CodecType::TELETEXT:
         case CodecType::DVB_SUBTITLES:
+        case CodecType::AVS3_AUDIO:
         default:
             return false;
     }
@@ -186,7 +190,8 @@ bool ts::CodecTypeIsSubtitles(CodecType ct)
         case CodecType::AV1:
         case CodecType::DTS:
         case CodecType::DTSHD:
-        case CodecType::AVS3:
+        case CodecType::AVS3_VIDEO:
+        case CodecType::AVS3_AUDIO:
         default:
             return false;
     }

--- a/src/libtsduck/dtv/codec/tsCodecType.h
+++ b/src/libtsduck/dtv/codec/tsCodecType.h
@@ -54,7 +54,8 @@ namespace ts {
         DTSHD,         //!< HD Digital Theater Systems audio, aka DTS++.
         TELETEXT,      //!< Teletext pages or subtitles, ETSI EN 300 706.
         DVB_SUBTITLES, //!< DVB subtitles, ETSI EN 300 743.
-        AVS3,          //!< AVS3 video (AVS is Chinese Audio Video Standards).
+        AVS3_VIDEO,    //!< AVS3 video (AVS is Audio Video Standards workgroup of China).
+        AVS3_AUDIO,    //!< AVS3 audio (AVS is Audio Video Standards workgroup of China).
     };
     TS_POP_WARNING()
 

--- a/src/libtsduck/dtv/descriptors/avs/notes.txt
+++ b/src/libtsduck/dtv/descriptors/avs/notes.txt
@@ -1,0 +1,34 @@
+The FCD 1.0 version of the T/AI 109.7 signalling specification has removed
+the inclusion of anc_data_block() in both the AVS2 and AVS3 audio descriptors,
+however the source code files are retained here until final determination of 
+its removal and/or availability in another descriptor.
+
+tsAVSANCDataBlockType.arch-cpp --> tsAVSANCDataBlockType.cpp
+tsAVSANCDataBlockType.arch-h --> tsAVSANCDataBlockType.h
+tsAVSANCDataBlockType.arch-names --> tsAVSANCDataBlockType.names
+
+It can be included in relevant XML files by including the following definition
+	<!-- optional 0..15 allowed  -->
+	<anc_data_block>
+	  <!-- one object_extension_meta_block or loudness_metadata_block element per anc_data_block -->
+	  <object_extension_metadata_block
+		maxObjChannelNum="uint8, required"
+		objChannelLock_maxDist="uint4, optional"
+		objDiffuse="uint7, required"
+		objGain="uint8, required"
+		objDivergence="uint4, required"
+		objDivergencePosRange="uint4, optional (required if objDivergence > 0)"/>
+
+	  <loudness_metadata_block
+		samplePeakLevel="uint12, optional"
+		truePeakLevel="uint12, required"
+		loudnessMeasure="uint4, required">
+
+		<!-- up to 15 loudness values -->
+		<loudnessValue
+		  loudnessValDef="uint4, reqiured"
+		  loudnessVal="uint8, required"/>
+	  </loudness_metadata_block>
+	</anc_data_block>
+	
+	

--- a/src/libtsduck/dtv/descriptors/avs/tsAVS2AudioDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVS2AudioDescriptor.adoc
@@ -1,0 +1,27 @@
+==== AVS2_audio_descriptor
+
+Defined by AVS in <<AVS-TAI-109.7>>.
+
+[source,xml]
+----
+<AVS2_audio_descriptor
+    num_channels="uint8, required"
+    sample_rate_index="uint4, required"
+    language="char3, optional"
+    description="string, optional">
+
+  <version_info
+    audio_codec_id="uint4, required"
+    coding_profile="basic|object, required"
+    bitrate_index="uint4, optional (required if audio_codec_id=0)"
+    bitstream_type="uniform|variable, optional (required if audio_codec_id=0)"
+    raw_frame_length="uint16, optional (required if audio_codec_id=0)"
+    resolution="8 bits|16 bits|24 bits, required">
+  </version_info>
+
+  <additional_info>
+    Hexadecimal content
+  </additional_info>
+  
+</AVS2_audio_descriptor>
+----

--- a/src/libtsduck/dtv/descriptors/avs/tsAVS2AudioDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVS2AudioDescriptor.cpp
@@ -1,0 +1,264 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2024, Paul Higgs
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsAVS2AudioDescriptor.h"
+#include "tsAVS3AudioDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+
+#include "tsDVBCharTableUTF16.h"
+
+
+#define MY_XML_NAME u"AVS2_audio_descriptor"
+#define MY_CLASS ts::AVS2AudioDescriptor
+#define MY_DID ts::DID_AVS2_AUDIO
+#define MY_PDS ts::PDS_AVSAudio
+#define MY_STD ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::Private(MY_DID, MY_PDS), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+
+//----------------------------------------------------------------------------
+// Constructors
+//----------------------------------------------------------------------------
+
+ts::AVS2AudioDescriptor::AVS2AudioDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, MY_PDS)
+{
+}
+
+void ts::AVS2AudioDescriptor::clearContent()
+{
+    num_channels = 0;
+    sample_rate_index = 0;
+    description.reset();
+    language.reset();
+    avs_version.reset();
+    additional_info.clear();
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::AVS2AudioDescriptor::avs_version_info::serialize(PSIBuffer& buf) const
+{
+    buf.putBits(audio_codec_id, 4);
+    buf.putBit(0);  // anc_data_index
+    buf.putBits(coding_profile, 3);
+    if (audio_codec_id == 0) {
+        buf.putBits(bitrate_index, 4);
+        buf.putBits(bitstream_type, 1);
+        buf.putBits(0xFF, 3);
+        buf.putUInt16(raw_frame_length);
+    }
+    buf.putBits(resolution, 2);
+    buf.putBits(0xFF, 6);
+}
+
+void ts::AVS2AudioDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putUInt8(num_channels);
+    buf.putBits(sample_rate_index, 4);
+    buf.putBit(avs_version.has_value());  // avs_version_flag
+    buf.putBit(description.has_value());  // text_present_flag
+    buf.putBit(language.has_value());     // language_present_flag
+    buf.putBits(0x00, 1);
+    if (description.has_value()) {
+        buf.putStringWithByteLength(description.value(), 0, NPOS, &ts::DVBCharTableUTF16::RAW_UNICODE);
+    }
+    if (language.has_value()) {
+        buf.putLanguageCode(language.value());
+    }
+    if (avs_version.has_value()) {
+        avs_version.value().serialize(buf);
+    }
+    buf.putBytes(additional_info);
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::AVS2AudioDescriptor::avs_version_info::deserialize(PSIBuffer& buf)
+{
+    audio_codec_id = buf.getBits<uint8_t>(4);
+    buf.skipBits(1);   // anc_data_index
+    coding_profile = buf.getBits<uint8_t>(3);
+    if (audio_codec_id == 0) {
+        bitrate_index = buf.getBits<uint8_t>(4);
+        bitstream_type = buf.getBit();
+        buf.skipBits(3);
+        raw_frame_length = buf.getUInt16();
+    }
+    resolution = buf.getBits<uint8_t>(2);
+    buf.skipBits(6);
+}
+
+void ts::AVS2AudioDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    num_channels = buf.getUInt8();
+    buf.getBits(sample_rate_index, 4);
+    const bool avs_version_flag = buf.getBit();
+    const bool text_present_flag = buf.getBool();
+    const bool language_present_flag = buf.getBool();
+    buf.skipBits(1);
+    if (text_present_flag) {
+        description = buf.getStringWithByteLength(&ts::DVBCharTableUTF16::RAW_UNICODE);
+    }
+    if (language_present_flag) {
+        language = buf.getLanguageCode();
+    }
+    if (avs_version_flag) {
+        avs_version_info version(buf);
+        avs_version = version;
+    }
+    buf.getBytes(additional_info);
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::AVS2AudioDescriptor::avs_version_info::display(TablesDisplay& disp, PSIBuffer& buf, const ts::UString& margin, uint8_t _num_channels)
+{
+    uint8_t _audio_codec_id = buf.getBits<uint8_t>(4);
+    disp << margin << "Codec id: " << DataName(MY_XML_NAME, u"audio_codec_id", _audio_codec_id, NamesFlags::VALUE | NamesFlags::DECIMAL);
+    buf.skipBits(1);   // anc_data_index
+    disp << ", Coding profile: " << DataName(MY_XML_NAME, u"coding_profile", buf.getBits<uint8_t>(3), NamesFlags::VALUE | NamesFlags::DECIMAL); 
+    uint8_t _bitrate_index = 0, _bitstream_type = 0;
+    uint16_t _raw_frame_length = 0;
+    if (_audio_codec_id == AVS3AudioDescriptor::General_Coding) {
+        _bitrate_index = buf.getBits<uint8_t>(4);
+        _bitstream_type = buf.getBit();
+        buf.skipReservedBits(3);
+        _raw_frame_length = buf.getUInt16();
+    }
+    disp << ", Resolution: " << DataName(MY_XML_NAME, u"resolution", buf.getBits<uint8_t>(2), NamesFlags::VALUE | NamesFlags::DECIMAL) << std::endl;
+    buf.skipReservedBits(6);
+    if (_audio_codec_id == AVS3AudioDescriptor::General_Coding) {
+        disp << margin << "Bitrate: " << DataName(MY_XML_NAME, u"bitrate_index", _bitrate_index, NamesFlags::VALUE);
+        disp << ", Bitstream type: " << DataName(MY_XML_NAME, u"bitstream_type", _bitstream_type, NamesFlags::VALUE | NamesFlags::DECIMAL);
+        disp << ", Raw frame length: " << _raw_frame_length << std::endl;
+    }
+}
+
+void ts::AVS2AudioDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(2)) {
+        uint8_t _num_channels = buf.getUInt8();
+        disp << margin << "Channels: " << uint16_t(_num_channels);
+        disp << ", Sample rate (Hz): " << DataName(MY_XML_NAME, u"sample_rate_index", buf.getBits<uint8_t>(4), NamesFlags::VALUE | NamesFlags::DECIMAL) << std::endl;
+        const bool avs_version_flag = buf.getBit();
+        const bool text_present_flag = buf.getBool();
+        const bool language_present_flag = buf.getBool();
+        buf.skipReservedBits(1, 0);
+        if (text_present_flag) {
+            disp << margin << "Description: " << buf.getStringWithByteLength(&ts::DVBCharTableUTF16::RAW_UNICODE) << std::endl;
+        }
+        if (language_present_flag) {
+            disp << margin << "Language: " << buf.getLanguageCode() << std::endl;
+        }
+        if (avs_version_flag) {
+            avs_version_info::display(disp, buf, margin, _num_channels);
+        }
+        disp.displayPrivateData(u"Additional information", buf, NPOS, margin);
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Enumerations for XML
+//----------------------------------------------------------------------------
+
+const ts::Enumeration ts::AVS2AudioDescriptor::CodingProfiles({
+    {u"basic", 0},
+    {u"object", 1},
+});
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::AVS2AudioDescriptor::avs_version_info::toXML(xml::Element* root) const
+{
+    root->setIntAttribute(u"audio_codec_id", audio_codec_id);
+    root->setEnumAttribute(AVS3AudioDescriptor::CodingProfiles, u"coding_profile", coding_profile);
+    root->setEnumAttribute(AVS3AudioDescriptor::Resolutions, u"resolution", resolution);
+    if (audio_codec_id == AVS3AudioDescriptor::General_Coding) {
+        root->setIntAttribute(u"bitrate_index", bitrate_index, true);
+        root->setEnumAttribute(AVS3AudioDescriptor::GeneralBitstreamTypes, u"bitstream_type", bitstream_type);
+        root->setIntAttribute(u"raw_frame_length", raw_frame_length);
+    }
+}
+
+void ts::AVS2AudioDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"num_channels", num_channels);
+    root->setIntAttribute(u"sample_rate_index", sample_rate_index);
+    if (description.has_value()) {
+        root->setAttribute(u"description", description.value());
+    }
+    if (language.has_value()) {
+        root->setAttribute(u"language", language.value());
+    }
+    if (avs_version.has_value()) {
+        avs_version.value().toXML(root->addElement(u"version_info"));
+    }
+    root->addHexaTextChild(u"additional_info", additional_info, true);
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::AVS2AudioDescriptor::avs_version_info::fromXML(const xml::Element* element)
+{
+    bool ok = element->getIntAttribute(audio_codec_id, u"audio_codec_id", true, 0, 0, 15) &&
+              element->getIntEnumAttribute(coding_profile, AVS2AudioDescriptor::CodingProfiles, u"coding_profile", true) &&
+              element->getIntEnumAttribute(resolution, AVS3AudioDescriptor::Resolutions, u"resolution", true);
+    if (ok && (audio_codec_id == AVS3AudioDescriptor::General_Coding)) {
+        ok = element->getIntAttribute(bitrate_index, u"bitrate_index", true, 0, 0, 0x0f) &&
+             element->getEnumAttribute(bitstream_type, AVS3AudioDescriptor::GeneralBitstreamTypes, u"bitstream_type", true) &&
+             element->getIntAttribute(raw_frame_length, u"raw_frame_length", true);
+    }
+    if ((audio_codec_id != AVS3AudioDescriptor::General_Coding) && (element->hasAttribute(u"bitrate_index") || element->hasAttribute(u"bitstream_type") || element->hasAttribute(u"raw_frame_length"))) {
+        element->report().warning(u"bitrate_index, bitstream_type and raw_frame_length attributes are only applicable for audio_codec_id=0, in <%s>, line %d", element->name(), element->lineNumber());
+    }
+    return ok;
+}
+
+bool ts::AVS2AudioDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    xml::ElementVector version_info;
+    bool ok = element->getIntAttribute(num_channels, u"num_channels", true) &&
+              element->getIntAttribute(sample_rate_index, u"sample_rate_index", true, 0, 0, 12) &&
+              element->getOptionalAttribute(description, u"description", 0, 255) &&
+              element->getOptionalAttribute(language, u"language", 3, 3) &&
+              element->getChildren(version_info, u"version_info", 0, 1) &&
+              element->getHexaTextChild(additional_info, u"additional_info");
+    if (!version_info.empty()) {
+        avs_version_info vi;
+        if (vi.fromXML(version_info[0])) {
+            avs_version = vi;
+        }
+        else {
+            ok = false;
+        }
+    }
+    return ok;
+}

--- a/src/libtsduck/dtv/descriptors/avs/tsAVS2AudioDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVS2AudioDescriptor.h
@@ -1,0 +1,101 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2024, Paul Higgs
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of an AVS2_audio_descriptor
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+#include "tsPSIBuffer.h"
+#include "tsTablesDisplay.h"
+#include "tsxmlElement.h"
+#include "tsByteBlock.h"
+
+namespace ts {
+    //!
+    //! Representation of an AVS2_audio_descriptor.
+    //!
+    //! @see T/AI 109-7.
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL AVS2AudioDescriptor : public AbstractDescriptor
+    {
+    public:
+        //!
+        //! information specific to version 1 of AVS2 audio
+        //! used when avs_info_flag == 1
+        //! 
+        class TSDUCKDLL avs_version_info
+        {
+        public:
+            uint8_t  audio_codec_id = 0;       //!< 4 bits. the audio coding method (common or lossless)
+            uint8_t  coding_profile = 0;       //!< 3 bits.  basic framework or object metadata based framework
+            uint8_t  bitrate_index = 0;        //!< 4 bits. index to bit rate tables (A.11~A.13) in GB/T33475.3
+            int      bitstream_type = 0;       //!< 1 bit.  the bitsream type : 0 = uniform, 1 = variable
+            uint16_t raw_frame_length = 0;     //!< according to Appendix A.2 of GB/T33475.3
+            uint8_t  resolution = 0;           //!< 2 bits. the number of bits per sample 0=8, 1=16, 3=24
+
+            //!
+            //! Default constructor
+            //!
+            avs_version_info() = default;
+            //!
+            //! Read-in constructor.
+            //! @param [in,out] buf Deserialization buffer.
+            //!
+            avs_version_info(PSIBuffer& buf) : avs_version_info() { deserialize(buf); }
+
+            //! @cond nodoxygen
+            // Delegated methods.
+            void serialize(PSIBuffer& buf) const;
+            void deserialize(PSIBuffer& buf);
+            bool fromXML(const xml::Element* element);
+            void toXML(xml::Element* root) const;
+            static void display(ts::TablesDisplay& display, PSIBuffer& buf, const ts::UString& margin, uint8_t _num_channels);
+            //! @endcond
+        };
+
+        // Public members:
+        uint8_t num_channels = 0;       //!< The number of channels in the AVS2 audio strema
+        uint8_t sample_rate_index = 0;  //!< 4 bits.  index to sample rate table (C.3) in GB/T33475.3 
+       
+        std::optional<UString> description {};          //!< description of the AVS2 audio stream
+        std::optional<UString> language {};             //!< 3-byte language of the audio stream
+        std::optional<avs_version_info> avs_version {}; //!< version specific information
+
+        ByteBlock additional_info {};                   //!< additional (non-standardised) information
+
+        //!
+        //! Default constructor.
+        //!
+        AVS2AudioDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] desc A binary descriptor to deserialize.
+        //!
+        AVS2AudioDescriptor(DuckContext& duck, const Descriptor& desc) :
+            AVS2AudioDescriptor() { deserialize(duck, desc); }
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+        // Enumerations for XML.
+        static const Enumeration CodingProfiles;    //!< premitted ciding profiles - see 
+
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}

--- a/src/libtsduck/dtv/descriptors/avs/tsAVS2AudioDescriptor.names
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVS2AudioDescriptor.names
@@ -1,0 +1,76 @@
+[AVS2_audio_descriptor.sample_rate_index]
+Bits = 4
+# GB/T 33475.3, table C.8: Mapping to Sampling Rate (Hz)
+0 = 8000
+1 = 11025
+2 = 12000
+3 = 16000
+4 = 22050
+5 = 24000
+6 = 32000
+7 = 44100
+8 = 48000
+9 = 88200
+10 = 96000
+11 = 174600
+12 = 192000
+13-15 = Reserved
+
+[AVS2_audio_descriptor.audio_codec_id]
+Bits = 2
+0 = common audio encoding data
+1 = lossless audio encoding data
+2-3 = Reserved
+
+[AVS2_audio_descriptor.coding_profile]
+Bits = 2
+0 = basic framework
+1 = object metadata coding framework
+2-3 = Reserved
+
+[AVS2_audio_descriptor.resolution]
+Inherit = AVS3_audio_descriptor.resolution
+
+[AVS2_audio_descriptor.bitrate_index]
+Bits = 8
+# GB/T 33475.3, tables A.11 - A.13
+# table A.11 - bitrates for Mono coding
+0x00 = 16
+0x01 = 32
+0x02 = 44
+0x03 = 56
+0x04 = 64
+0x05 = 72
+0x06 = 80
+0x07 = 96
+0x08 = 128
+0x09 = 144
+0x0a = 164
+0x0b = 192
+0x0c-0x0f = Reserved
+# table A.12  - bitrates for Dual-channel stereo coding
+0x10 = 24
+0x11 = 32
+0x12 = 48
+0x13 = 64
+0x14 = 80
+0x15 = 96
+0x16 = 128
+0x17 = 144
+0x18 = 192
+0x19 = 256
+0x1a = 320
+0x1b-0x1f = Reserved
+# table A.12 - bitrates for 5.1 multichannel coding
+0x020 = 192
+0x021 = 256
+0x022 = 320
+0x023 = 384
+0x024 = 448
+0x025 = 512
+0x026 = 640
+0x027 = 720
+0x28-0x3f = Reserved
+
+[AVS2_audio_descriptor.bitstream_type]
+Inherit = AVS3_audio_descriptor.bitstream_type

--- a/src/libtsduck/dtv/descriptors/avs/tsAVS2AudioDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVS2AudioDescriptor.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <AVS2_audio_descriptor
+        num_channels="uint8, required"
+        sample_rate_index="uint4, required"
+        language="char3, optional"
+        description="string, optional">
+
+      <version_info
+        audio_codec_id="uint4, required"
+        coding_profile="basic|object, required"
+        bitrate_index="uint4, optional (required if audio_codec_id=0)"
+        bitstream_type="uniform|variable, optional (required if audio_codec_id=0)"
+        raw_frame_length="uint16, optional (required if audio_codec_id=0)"
+        resolution="8 bits|16 bits|24 bits, required">
+      </version_info>
+
+      <additional_info>
+        Hexadecimal content
+      </additional_info>
+      
+    </AVS2_audio_descriptor>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/avs/tsAVS3AudioDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVS3AudioDescriptor.adoc
@@ -1,0 +1,40 @@
+==== AVS3_audio_descriptor
+
+Defined by AVS in <<AVS-TAI-109.7>>.
+
+[source,xml]
+----
+<AVS3_audio_descriptor
+    sampling_frequency_index="uint4, required"
+    resolution="8 bits|16 bits|24 bits, required">
+  
+  <!-- required for audio_codec_id==0 (General High Rate Coding) -->
+  <general_coding
+    coding_profile="basic|object|HOA, required"
+    bitrate_index="uint4, required"
+    bitstream_type="uniform|variable, required"
+    channel_number_index="uint7, required"
+    raw_frame_length="uint16, required">
+  </general_coding>
+
+  <!-- required for audio_codec_id==1 (Lossless Coding)-->
+  <lossless_coding
+    sampling_frequency="uint24, optional"
+    coding_profile="basic|object|HOA, required"
+    channel_number="uint8, required">
+  </lossless_coding>
+
+  <!-- required for audio_codec_id==2 (General Full Rate Coding)-->
+  <fullrate_coding
+    nn_type="uint3, required"
+    channel_num_index="uint7, optional"
+    num_objects="uint7, optional"
+    hoa_order="uint4, optional"
+    total_bitrate="uint16, required"/>
+
+  <additional_info>
+    Hexadecimal content
+  </additional_info>
+  
+</AVS3_audio_descriptor>
+----

--- a/src/libtsduck/dtv/descriptors/avs/tsAVS3AudioDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVS3AudioDescriptor.cpp
@@ -1,0 +1,500 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2024, Paul Higgs
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsAVS3AudioDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+
+
+#define MY_XML_NAME u"AVS3_audio_descriptor"
+#define MY_CLASS ts::AVS3AudioDescriptor
+#define MY_DID ts::DID_AVS3_AUDIO
+#define MY_PDS ts::PDS_AVSAudio
+#define MY_STD ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::Private(MY_DID, MY_PDS), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+
+//----------------------------------------------------------------------------
+// Constructors
+//----------------------------------------------------------------------------
+
+ts::AVS3AudioDescriptor::AVS3AudioDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, MY_PDS)
+{
+}
+
+void ts::AVS3AudioDescriptor::clearContent()
+{
+    audio_codec_id = 0;
+    sampling_frequency_index = 0;
+    sampling_frequency = 0;
+    resolution = 0;
+    coding_data = std::monostate {};
+    additional_info.clear();
+}
+
+
+//----------------------------------------------------------------------------
+// Helpers
+//----------------------------------------------------------------------------
+
+uint8_t ts::AVS3AudioDescriptor::fullrate_coding_type::content_type() const
+{
+    if (channel_num_index.has_value() && num_objects.has_value()) {
+        return Mix_signal;
+    }
+    else if (channel_num_index.has_value()) {
+        return Channel_signal;
+    }
+    else if (num_objects.has_value()) {
+        return Object_signal;
+    }
+    else if (hoa_order.has_value()) {
+        return HOA_signal;
+    }
+    return INVALID_CONTENT_TYPE;
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::AVS3AudioDescriptor::general_coding_type::serialize(PSIBuffer& buf) const
+{
+    buf.putBit(0);  // anc_data_index
+    buf.putBits(coding_profile, 3);
+    buf.putBits(bitrate_index, 4);
+    buf.putBits(bitstream_type, 1);
+    buf.putBits(channel_number_index, 7);
+    buf.putUInt16(raw_frame_length);
+}
+void ts::AVS3AudioDescriptor::lossless_coding_type::serialize(PSIBuffer& buf, uint8_t _sampling_frequency_index) const
+{
+    if (_sampling_frequency_index == 0x0F) {
+        buf.putUInt24(sampling_frequency);
+    }
+    buf.putBit(0);  // anc_data_index
+    buf.putBits(coding_profile, 3);
+    buf.putBits(0xFF, 4);
+    buf.putUInt8(channel_number);
+}
+
+void ts::AVS3AudioDescriptor::fullrate_coding_type::serialize(PSIBuffer& buf) const
+{
+    buf.putBits(nn_type, 3);
+    buf.putBits(0xFF, 1);
+    const uint8_t _content_type = content_type();
+    buf.putBits(_content_type, 4);
+    switch (_content_type) {
+        case Channel_signal:
+            buf.putBits(channel_num_index.value_or(0), 7);
+            buf.putBits(0xFF, 1);
+            break;
+        case Object_signal:
+            buf.putBits(num_objects.value_or(0), 7);
+            buf.putBits(0xFF, 1);
+            break;
+        case Mix_signal:
+            buf.putBits(channel_num_index.value_or(0), 7);
+            buf.putBits(0xFF, 1);
+            buf.putBits(num_objects.value_or(0), 7);
+            buf.putBits(0xFF, 1);
+            break;
+        case HOA_signal:
+            buf.putBits(hoa_order.value_or(0), 4);
+            buf.putBits(0xFF, 4);
+            break;
+        default:
+            break;
+    }
+    buf.putUInt16(total_bitrate);
+}
+
+void ts::AVS3AudioDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putBits(audio_codec_id, 4);
+    buf.putBits(sampling_frequency_index, 4);
+    switch (audio_codec_id) {
+        case General_Coding:
+            if (std::holds_alternative<general_coding_type>(coding_data)) {
+                std::get<general_coding_type>(coding_data).serialize(buf);
+            }
+            break;
+        case Lossless_Coding:
+            if (std::holds_alternative<lossless_coding_type>(coding_data)) {
+                std::get<lossless_coding_type>(coding_data).serialize(buf, sampling_frequency_index);
+            }
+            break;
+        case Fullrate_Coding:
+            if (std::holds_alternative<fullrate_coding_type>(coding_data)) {
+                std::get<fullrate_coding_type>(coding_data).serialize(buf);
+            } 
+            break;
+        default:
+            break;
+    }
+    buf.putBits(resolution, 2);
+    buf.putBits(0xFF, 6);
+    buf.putBytes(additional_info);
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::AVS3AudioDescriptor::general_coding_type::deserialize(PSIBuffer& buf)
+{
+    buf.skipBits(1);  // anc_data_index
+    buf.getBits(coding_profile, 3);
+    buf.getBits(bitrate_index, 4);
+    buf.getBits(bitstream_type, 1);
+    buf.getBits(channel_number_index, 7);
+    raw_frame_length = buf.getUInt16();
+}
+
+void ts::AVS3AudioDescriptor::lossless_coding_type::deserialize(PSIBuffer& buf, uint8_t _sampling_frequency_index)
+{
+    if (_sampling_frequency_index == 0x0F) {
+        sampling_frequency = buf.getUInt24();
+    }
+    buf.skipBits(1);  // anc_data_index
+    buf.getBits(coding_profile, 3);
+    buf.skipBits(4);
+    channel_number = buf.getUInt8();
+}
+
+void ts::AVS3AudioDescriptor::fullrate_coding_type::deserialize(PSIBuffer& buf)
+{
+    buf.getBits(nn_type, 3);
+    buf.skipBits(1);
+    const uint8_t content_type = buf.getBits<uint8_t>(4);
+    switch (content_type) {
+        case Channel_signal:
+            buf.getBits(channel_num_index, 7);
+            buf.skipBits(1);
+            break;
+        case Object_signal:
+            buf.getBits(num_objects, 7);
+            buf.skipBits(1);
+            break;
+        case Mix_signal:
+            buf.getBits(channel_num_index, 7);
+            buf.skipBits(1);
+            buf.getBits(num_objects, 7);
+            buf.skipBits(1);
+            break;
+        case HOA_signal:
+            buf.getBits(hoa_order, 4);
+            buf.skipBits(4);
+            break;
+        default:
+            break;
+    }
+    total_bitrate = buf.getUInt16();
+}
+
+void ts::AVS3AudioDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    buf.getBits(audio_codec_id, 4);
+    buf.getBits(sampling_frequency_index, 4);
+
+    if (audio_codec_id == General_Coding) {
+        general_coding_type gc(buf);
+        coding_data = gc;
+    }
+    else if (audio_codec_id == Lossless_Coding) {
+        lossless_coding_type lc(buf, sampling_frequency_index);
+        coding_data = lc;
+    }
+    else if (audio_codec_id == Fullrate_Coding) {
+        fullrate_coding_type fc(buf);
+        coding_data = fc;
+    }
+    else {
+        coding_data = std::monostate {};
+    }
+    buf.getBits(resolution, 2);
+    buf.skipBits(6);
+    buf.getBytes(additional_info);
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::AVS3AudioDescriptor::general_coding_type::display(TablesDisplay& disp, const UString& margin)
+{
+    disp << margin << "General High-rate Coding. Coding Profile: " << DataName(MY_XML_NAME, u"coding_profile", coding_profile, NamesFlags::VALUE);
+    disp << ", Bitstream Type: " << GeneralBitstreamTypes.name(bitstream_type, true) << std::endl;
+    disp << margin << "Bitrate: " << DataName(MY_XML_NAME, u"channel_bitrate", (channel_number_index << 8) | bitrate_index, NamesFlags::VALUE)
+         << ", Raw Frame Length: " << raw_frame_length << std::endl;
+}
+
+void ts::AVS3AudioDescriptor::lossless_coding_type::display(TablesDisplay& disp, const UString& margin, uint8_t _sampling_frequency_index)
+{
+    if (_sampling_frequency_index == 0xF) {
+        disp << ", Sampling Frequency (actual): " << sampling_frequency << " Hz" << std::endl;
+    }
+    else {
+        disp << ", Sampling Frequency (index): " << DataName(MY_XML_NAME, u"sampling_frequency_index", _sampling_frequency_index, NamesFlags::VALUE) << std::endl;
+    }
+    disp << margin << "Lossless Coding. Coding Profile: " << DataName(MY_XML_NAME, u"coding_profile", coding_profile, NamesFlags::VALUE);
+    disp << ", channel number: " << int(channel_number) << std::endl;
+}
+
+void ts::AVS3AudioDescriptor::fullrate_coding_type::display(TablesDisplay& disp, const UString& margin)
+{
+    const UString err_msg = u"**ERROR**";
+    bool ok = true;
+    disp << margin << "General Full-rate Coding. NN Type: " << DataName(MY_XML_NAME, u"nn_type", nn_type, NamesFlags::VALUE);
+    switch (content_type()) {
+        case Channel_signal:
+            disp << ", Channel Signal - "
+                 << (channel_num_index.has_value() ? DataName(MY_XML_NAME, u"channel_number_idx", channel_num_index.value(), NamesFlags::VALUE) : err_msg);
+            break;
+        case Object_signal:
+            disp << ", Object Signal - "
+                 << (num_objects.has_value() ? UString::Format(u"number of objects: %d", num_objects.value()) : err_msg);
+            break;
+        case Mix_signal:
+            disp << ", Mix Signal - "
+                 << (channel_num_index.has_value() ? DataName(MY_XML_NAME, u"channel_number_idx", channel_num_index.value(), NamesFlags::VALUE) : err_msg)
+                 << (num_objects.has_value() ? UString::Format(u", number of objects: %d", num_objects.value()) : err_msg);
+            break;
+        case HOA_signal:
+            disp << ", HOA Signal - "
+                 << (hoa_order.has_value() ? UString::Format(u"order: %d", hoa_order.value() + 1) : err_msg);
+            break;
+        default:
+            disp << " ** Invalid content_type **";
+            ok = false;
+            break;
+    }
+    if (ok) {
+        disp << ", total bitrate: " << total_bitrate;
+    }
+    disp << std::endl;
+}
+
+
+void ts::AVS3AudioDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(2)) {
+        const uint8_t _codec_id = buf.getBits<uint8_t>(4);
+        disp << margin << "Codec ID: " << DataName(MY_XML_NAME, u"audio_codec_id", _codec_id, NamesFlags::VALUE);
+        const uint8_t _sampling_frequency_index = buf.getBits<uint8_t>(4);
+        switch (_codec_id) {
+            case General_Coding: {
+                    disp << ", Sampling Frequency (index): " << DataName(MY_XML_NAME, u"sampling_frequency_index", _sampling_frequency_index, NamesFlags::VALUE) << std::endl;
+                    general_coding_type gc(buf);
+                    gc.display(disp, margin);
+                }   
+                break;
+            case Lossless_Coding: {
+                    lossless_coding_type lc(buf, _sampling_frequency_index);
+                    lc.display(disp, margin, _sampling_frequency_index);
+                }
+                break;
+            case Fullrate_Coding: {
+                    disp << ", Sampling Frequency (index): " << DataName(MY_XML_NAME, u"sampling_frequency_index", _sampling_frequency_index, NamesFlags::VALUE) << std::endl;
+                    fullrate_coding_type fc(buf);
+                    fc.display(disp, margin);           
+                }
+                break;
+            default:
+                break;
+        }
+        disp << margin << "Resolution: " << DataName(MY_XML_NAME, u"resolution", buf.getBits<uint8_t>(2), NamesFlags::VALUE) << std::endl;
+        buf.skipBits(6);
+        disp.displayPrivateData(u"Additional information", buf, NPOS, margin);
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Enumerations for XML
+//----------------------------------------------------------------------------
+
+const ts::Enumeration ts::AVS3AudioDescriptor::GeneralBitstreamTypes({
+    {u"uniform", 0},
+    {u"variable", 1},
+});
+
+const ts::Enumeration ts::AVS3AudioDescriptor::Resolutions({
+    {u"8 bits", 0},
+    {u"16 bits", 1},
+    {u"24 bits", 2},
+});
+
+const ts::Enumeration ts::AVS3AudioDescriptor::CodingProfiles({
+    {u"basic", 0},
+    {u"object", 1},
+    {u"HOA", 2},
+});
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::AVS3AudioDescriptor::general_coding_type::toXML(xml::Element* root) const
+{
+    root->setEnumAttribute(CodingProfiles, u"coding_profile", coding_profile);
+    root->setIntAttribute(u"bitrate_index", bitrate_index, true);
+    root->setEnumAttribute(GeneralBitstreamTypes, u"bitstream_type", bitstream_type);
+    root->setIntAttribute(u"channel_number_index", channel_number_index, true);
+    root->setIntAttribute(u"raw_frame_length", raw_frame_length);
+}
+
+void ts::AVS3AudioDescriptor::lossless_coding_type::toXML(xml::Element* root, uint8_t _sampling_frequency_index) const
+{
+    if (_sampling_frequency_index == 0xF) {
+        root->setIntAttribute(u"sampling_frequency", sampling_frequency, true);
+    }
+    root->setEnumAttribute(CodingProfiles, u"coding_profile", coding_profile);
+    root->setIntAttribute(u"channel_number", channel_number);
+}
+
+void ts::AVS3AudioDescriptor::fullrate_coding_type::toXML(xml::Element* root) const
+{
+    root->setIntAttribute(u"nn_type", nn_type);
+    root->setOptionalIntAttribute(u"channel_num_index", channel_num_index, true);
+    root->setOptionalIntAttribute(u"num_objects", num_objects);
+    root->setOptionalIntAttribute(u"hoa_order", hoa_order);
+    root->setIntAttribute(u"total_bitrate", total_bitrate);
+}
+
+void ts::AVS3AudioDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"sampling_frequency_index", sampling_frequency_index, true);
+    root->setEnumAttribute(Resolutions, u"resolution", resolution);
+
+    if (std::holds_alternative<general_coding_type>(coding_data)) {
+        std::get<general_coding_type>(coding_data).toXML(root->addElement(u"general_coding"));
+    }
+    else if (std::holds_alternative<lossless_coding_type>(coding_data)) {
+        std::get<lossless_coding_type>(coding_data).toXML(root->addElement(u"lossless_coding"), sampling_frequency_index);
+    }
+    else if (std::holds_alternative<fullrate_coding_type>(coding_data)) {
+        std::get<fullrate_coding_type>(coding_data).toXML(root->addElement(u"fullrate_coding"));
+    }
+    root->addHexaTextChild(u"additional_info", additional_info, true);
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::AVS3AudioDescriptor::general_coding_type::fromXML(const xml::Element* element)
+{
+    return element->getEnumAttribute(coding_profile, CodingProfiles, u"coding_profile", true) &&
+           element->getIntAttribute(bitrate_index, u"bitrate_index", true, 0, 0, 15) &&
+           element->getEnumAttribute(bitstream_type, GeneralBitstreamTypes, u"bitstream_type", true, 0) &&
+           element->getIntAttribute(channel_number_index, u"channel_number_index", true, 0, 0, 127) &&
+           element->getIntAttribute(raw_frame_length, u"raw_frame_length", true);
+}
+
+bool ts::AVS3AudioDescriptor::lossless_coding_type::fromXML(const xml::Element* element, uint8_t _sampling_frequency_index)
+{
+    xml::ElementVector anc_blocks;
+    bool ok = element->getEnumAttribute(coding_profile, CodingProfiles, u"coding_profile", true) &&
+              element->getIntAttribute(channel_number, u"channel_number", true) &&
+              element->getIntAttribute(sampling_frequency, u"sampling_frequency", (_sampling_frequency_index == 0xF), 0, 0, 0x00FFFFFF);
+
+    if (ok && (element->hasAttribute(u"sampling_frequency")) && (_sampling_frequency_index != 0xF)) {
+        element->report().warning(u"sampling_frequency is ignored when sampling_frequency_index != 0xF in <%s>, line %d", element->name(), element->lineNumber());
+    }
+    return ok;
+}
+
+bool ts::AVS3AudioDescriptor::fullrate_coding_type::fromXML(const xml::Element* element)
+{
+    bool ok = element->getIntAttribute(nn_type, u"nn_type", true, 0, 0, 7) &&
+              element->getOptionalIntAttribute(channel_num_index, u"channel_num_index", 0, 127) &&
+              element->getOptionalIntAttribute(num_objects, u"num_objects", 0, 127) &&
+              element->getOptionalIntAttribute(hoa_order, u"hoa_order", 0, 127) &&
+              element->getIntAttribute(total_bitrate, u"total_bitrate", true);
+    if (content_type() == INVALID_CONTENT_TYPE) {
+        element->report().error(u"invalid combination of channel_num_index, num_objects, hoa_order is specified in <%s>, line %d", element->name(), element->lineNumber());
+        ok = false;
+    }
+    return ok;
+}
+
+bool ts::AVS3AudioDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    ts::xml::ElementVector gce, lce, fce;
+    bool ok = element->getIntAttribute(sampling_frequency_index, u"sampling_frequency_index", true) &&
+              element->getEnumAttribute(resolution, Resolutions, u"resolution", true) &&
+              element->getChildren(gce, u"general_coding", 0, 1) &&
+              element->getChildren(lce, u"lossless_coding", 0, 1) &&
+              element->getChildren(fce, u"fullrate_coding", 0, 1) &&
+              element->getHexaTextChild(additional_info, u"additional_info", false);
+
+    if (ok && (gce.size() + lce.size() + fce.size() > 1)) {
+        element->report().error(u"only one of <general_coding>, <lossless_coding> or <fullrate_coding> is permitted in <%s>, line %d", element->name(), element->lineNumber());
+        ok = false;
+    }
+    if (ok) {
+        if (!gce.empty()) {
+            audio_codec_id = General_Coding;
+            general_coding_type gc;
+            if (gc.fromXML(gce[0])) {
+                coding_data = gc;
+            }
+            else {
+                ok = false;
+            }
+        }
+        else if (!lce.empty()) {
+            audio_codec_id = Lossless_Coding;
+            lossless_coding_type lc;
+            if (lc.fromXML(lce[0], sampling_frequency_index)) {
+                coding_data = lc;
+            }
+            else {
+                ok = false;
+            }
+        }
+        else if (!fce.empty()) {
+            audio_codec_id = Fullrate_Coding;
+            fullrate_coding_type fc;
+            if (fc.fromXML(fce[0])) {
+                coding_data = fc;
+            }
+            else {
+                ok = false;
+            }
+        }
+        else {
+            element->report().error(u"one of <general_coding>, <lossless_coding> or <fullrate_coding> is required in <%s>, line %d", element->name(), element->lineNumber());
+            coding_data = std::monostate {};
+            ok = false;
+        }
+    }
+    if (ok && (audio_codec_id == General_Coding || audio_codec_id == Fullrate_Coding) && (sampling_frequency_index > 0x8)) {
+        element->report().error(u"sampling_frequency_index must be 0x0..0x8 for General Coding and Fullrate Coding, in <%s> line %d", element->name(), element->lineNumber());
+        ok = false;
+    }
+    if (ok && (audio_codec_id == Lossless_Coding)) {
+        if ((sampling_frequency_index > 0x8) && (sampling_frequency_index < 0xF)) {
+            element->report().error(u"sampling_frequency_index must be 0x0..0x8 or 0xF for Lossless Coding, in <%s> line %d", element->name(), element->lineNumber());
+            ok = false;
+        }
+    }
+    return ok;
+}

--- a/src/libtsduck/dtv/descriptors/avs/tsAVS3AudioDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVS3AudioDescriptor.h
@@ -1,0 +1,186 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2024, Paul Higgs
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of an AVS3_audio_descriptor
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+//#include <variant>
+#include "tsAbstractDescriptor.h"
+#include "tsPSIBuffer.h"
+#include "tsTablesDisplay.h"
+#include "tsxmlElement.h"
+#include "tsByteBlock.h"
+#include "tsAVS2AudioDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of an AVS3_audio_descriptor.
+    //!
+    //! @see T/AI 109.7.
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL AVS3AudioDescriptor : public AbstractDescriptor
+    {
+    public:
+        //!
+        //! parametrs related to general audio coding - audio_codec_id = 0;
+        //! 
+        class TSDUCKDLL general_coding_type
+        {
+        public:
+            int                                coding_profile = 0;        //!< 3 bits. The coding type used in the bitstream.
+            uint8_t                            bitrate_index = 0;         //!< 4 bits. Index to bitrates in tables A.10 to A.20 of T/AI 109.3
+            int                                bitstream_type = 0;        //!< 1 bit. Indicates whether the bitstream coding is uniform or non-uniform.
+            uint8_t                            channel_number_index = 0;  //!< 7 bits. Index to the channel configuration table (A.*) in T/AI 109.3
+            uint16_t                           raw_frame_length = 0;      //!< Total length of the current frame in the bitstream.
+
+            //!
+            //! Default constructor.
+            //!
+            general_coding_type() = default;
+            //!
+            //! Read-in constructor.
+            //! @param [in,out] buf Deserialization buffer.
+            //!
+            general_coding_type(PSIBuffer& buf) : general_coding_type() { deserialize(buf); }
+
+            //! @cond nodoxygen
+            // Delegated methods.
+            void serialize(PSIBuffer& buf) const;
+            void deserialize(PSIBuffer& buf);
+            bool fromXML(const xml::Element* element);
+            void toXML(xml::Element* root) const;
+            void display(ts::TablesDisplay& display, const ts::UString& margin);
+            //! @endcond
+        };
+
+        //!
+        //! parametrs related to lossless audio coding - audio_codec_id = 1;
+        //!
+        class TSDUCKDLL lossless_coding_type
+        {
+        public:
+            uint32_t                           sampling_frequency = 0;  //!< 24 bits. Ths sampling frequency (in Hz) when lookup table cannot be used
+            int                                coding_profile = 0;      //!< 3 bits. The coding type used in the bitstream.
+            uint8_t                            channel_number = 0;      //!< indicates the number of channels
+
+            //!
+            //! Default constructor.
+            //!
+            lossless_coding_type() = default;
+            //!
+            //! Read-in constructor.
+            //! @param [in,out] buf Deserialization buffer.
+            //! @param [in] _sampling_frequency_index the index of teh sampling frequency from the containing class
+            //!
+            lossless_coding_type(PSIBuffer& buf, uint8_t _sampling_frequency_index) :
+                lossless_coding_type() { deserialize(buf, _sampling_frequency_index); }
+
+            //! @cond nodoxygen
+            // Delegated methods.
+            void serialize(PSIBuffer& buf, uint8_t _sampling_frequency_index) const;
+            void deserialize(PSIBuffer& buf, uint8_t _sampling_frequency_index);
+            bool fromXML(const xml::Element* element, uint8_t _sampling_frequency_index);
+            void toXML(xml::Element* root, uint8_t _sampling_frequency_index) const;
+            void display(ts::TablesDisplay& display, const ts::UString& margin, uint8_t _sampling_frequency_index);
+            //! @endcond
+        };
+
+        //!
+        //! parameters related to general full rate audio coding - audio_codec_id = 2;
+        //! 
+        class TSDUCKDLL fullrate_coding_type
+        {
+        public:
+            uint8_t                 nn_type = 0;            //!< 3 bits. Indicates the configuration of the neural network (basic or low complexity).
+            std::optional<uint8_t>  channel_num_index {};   //!< 7 bits. Index to the channel configuration table (A.*) in T/AI 109.3
+            std::optional<uint8_t>  num_objects {};         //!< 7 bits. The number of audio objects used in the audio sequence
+            std::optional<uint8_t>  hoa_order {};           //!< 4 bits. The HOA signal order (value + 1)
+            uint16_t                total_bitrate = 0;      //!< The total bit rate, in kbit/s, according to the value of content_type
+
+            //!
+            //! Default constructor.
+            //!
+            fullrate_coding_type() = default;
+            //!
+            //! Read-in constructor.
+            //! @param [in,out] buf Deserialization buffer.
+            //!
+            fullrate_coding_type(PSIBuffer& buf) : fullrate_coding_type() { deserialize(buf); }
+
+            //! @cond nodoxygen
+            // Delegated methods.
+            void serialize(PSIBuffer& buf) const;
+            void deserialize(PSIBuffer& buf);
+            bool fromXML(const xml::Element* element);
+            void toXML(xml::Element* root) const;
+            void display(ts::TablesDisplay& display, const ts::UString& margin);
+            //! @endcond
+
+            //!
+            //! Determine the content type (Mix_Signal, Channel_Signal, Object_Signal, HOA_Signal) according to
+            //! the values specified in the decaration
+            //! @returns the type of content (channel, object, hybrid or ambisonic) according to the data items specified
+            //! 
+            uint8_t content_type() const;           
+        };
+
+    public:
+        // Public members:
+        uint8_t   audio_codec_id = 0;               //!< 4 bits. the coding type in use
+        uint8_t   sampling_frequency_index = 0;     //!< 4 bits. Index to the sampling frequency table (A.9) of T/AI 109.3
+        uint32_t  sampling_frequency = 0;           //!< 24 bits, only of sampling_frequency_index = 0xf, Raw sampling frequency.
+        int       resolution = 0;                   //!< 2 bits. Number of quantization bits in the input signal (8, 16, 24)
+
+        std::variant<std::monostate, general_coding_type, lossless_coding_type, fullrate_coding_type> coding_data {}; //!< coding type specific data
+                
+        ByteBlock additional_info {};               //!< additional (non-standard) bytes carried in the descriptor
+
+        //!
+        //! Default constructor.
+        //!
+        AVS3AudioDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] desc A binary descriptor to deserialize.
+        //!
+        AVS3AudioDescriptor(DuckContext& duck, const Descriptor& desc) :
+            AVS3AudioDescriptor() { deserialize(duck, desc); }
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+
+        friend class AVS2AudioDescriptor;
+        static constexpr uint8_t General_Coding = 0x00;     //!< value for audio_codec_id when general high rate coding is used
+        static constexpr uint8_t Lossless_Coding = 0x01;    //!< value for audio_codec_id when lossless coding is used
+        static constexpr uint8_t Fullrate_Coding = 0x02;    //!< value for audio_codec_id when general full rate coding is used
+
+        static constexpr uint8_t Channel_signal = 0x0;      //!< value for content_type when channel based audio is used
+        static constexpr uint8_t Object_signal = 0x1;       //!< value for content_type when object based audio is used
+        static constexpr uint8_t Mix_signal = 0x2;          //!< value for content_type when hybrid (mix of channels and objects) audio is used
+        static constexpr uint8_t HOA_signal = 0x3;          //!< value for content_type when ambisonic audio is used
+        static constexpr uint8_t INVALID_CONTENT_TYPE = 0xF;  //!< value for content_type when audio coding method cannot be determined
+
+        // Enumerations for XML.
+        static const Enumeration GeneralBitstreamTypes;     //!< readable bitstream type values for XML
+        static const Enumeration Resolutions;               //!< readable resolution values for XML
+        static const Enumeration CodingProfiles;            //!< readable coding profiles for XML
+    };
+}

--- a/src/libtsduck/dtv/descriptors/avs/tsAVS3AudioDescriptor.names
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVS3AudioDescriptor.names
@@ -1,0 +1,190 @@
+[AVS3_audio_descriptor.audio_codec_id]
+Bits = 4
+0 = General high-rate
+1 = Lossless
+2 = General full-rate
+3-15 = Reserved
+
+[AVS3_audio_descriptor.resolution]
+Bits = 2
+# T/AI 109.3, annex A.2
+0 = 8 bits/sample
+1 = 16 bits/sample
+2 = 24 bits/sample
+3 = Reserved
+
+[AVS3_audio_descriptor.nn_type]
+Bits = 3
+# T/AI 109.3, annex A.2
+0 = basic
+1 = low-complexity
+2-7 = Reserved
+
+[AVS3_audio_descriptor.sampling_frequency_index]
+Bits = 4
+# T/AI 109.3, table A.9
+0x0 = 192000 Hz
+0x1 = 96000 Hz
+0x2 = 48000 Hz
+0x3 = 44100 Hz
+0x4 = 32000 Hz
+0x5 = 24000 Hz
+0x6 = 22050 Hz
+0x7 = 16000 Hz
+0x8 = 8000 Hz
+0x9-0xF = Reserved
+
+[AVS3_audio_descriptor.coding_profile]
+Bits = 3
+# T/AI 109.3, annex A.2
+0 = basic framework
+1 = object metadata coding framework
+2 = HOA data coding framework
+3-7 = Reserved
+
+[AVS3_audio_descriptor.channel_number_idx]
+Bits = 7
+# T/AI 109.3, table A.8
+0x0 = Mono
+0x1 = Dual-channel stereo
+0x2 = 5.1
+0x3 = 7.1
+0x4 = 10.2
+0x5 = 22.2
+0x6 = 4.0/FOA
+0x7 = 5.1.2
+0x8 = 5.1.4
+0x9 = 7.1.2
+0xa = 7.1.4
+0xb = 3rd order HOA
+0xc = 2nd order HOA
+0xd-0x7f = Reserved
+
+[AVS3_audio_descriptor.channel_bitrate]
+Bits = 16
+# T/AI 109.3,tables A.10 - A.20
+# upper 8 bits = channel_number_index, lower 8 bits - bitrate_index
+# table A.10 - bitrates for Mono coding
+0x0000 = 16
+0x0001 = 32
+0x0002 = 44
+0x0003 = 56
+0x0004 = 64
+0x0005 = 72
+0x0006 = 80
+0x0007 = 96
+0x0008 = 128
+0x0009 = 144
+0x000a = 164
+0x000b = 192
+0x000c-0x000f = Reserved
+0x0010-0x00ff = Disallowed
+# table A.11  - bitrates for Dual-channel stereo coding
+0x0100 = 24
+0x0101 = 32
+0x0102 = 48
+0x0103 = 64
+0x0104 = 80
+0x0105 = 96
+0x0106 = 128
+0x0107 = 144
+0x0108 = 192
+0x0109 = 256
+0x010a = 320
+0x010b-0x010f = Reserved
+0x0110-0x01ff = Disallowed
+# table A.12 - bitrates for 5.1 multichannel coding
+0x0200 = 192
+0x0201 = 256
+0x0202 = 320
+0x0203 = 384
+0x0204 = 448
+0x0205 = 512
+0x0206 = 640
+0x0207 = 720
+0x0208 = 144
+0x0209 = 96
+0x020a = 128
+0x020b = 160
+0x020c-0x020f = Reserved
+0x0210-0x02ff = Disallowed
+# table A.13 - bitrates for 7.1 multichannel coding
+0x0300 = 192
+0x0301 = 480
+0x0302 = 256
+0x0303 = 384
+0x0304 = 576
+0x0305 = 640
+0x0306 = 128
+0x0307 = 160
+0x0308-0x030f = Reserved
+0x0310-0x03ff = Disallowed
+# table A.14 - bitrates for 4.0/FOA coding
+0x0600 = 48
+0x0601 = 96
+0x0602 = 128
+0x0603 = 192
+0x0604 = 256
+0x0605-0x060f = Reserved
+0x0610-0x06ff = Disallowed
+# table A.15 - bitrates for 5.1.2 multi-channel coding
+0x0700 = 152
+0x0701 = 320
+0x0702 = 480
+0x0703 = 576
+0x0704-0x070f = Reserved
+0x0710-0x07ff = Disallowed
+# table A.16 - bitrates for 5.1.4 multi-channel coding
+0x0800 = 176
+0x0801 = 384
+0x0802 = 576
+0x0803 = 704
+0x0804 = 256
+0x0805 = 448
+0x0806-0x080f = Reserved
+0x0810-0x08ff = Disallowed
+# table A.17 - bitrates for 7.1.2 multi-channel coding
+0x0900 = 216
+0x0901 = 480
+0x0902 = 576
+0x0903 = 384
+0x0904 = 768
+0x0907-0x090f = Reserved
+0x0910-0x09ff = Disallowed
+# table A.18 - bitrates for 7.1.4 multi-channel coding
+0x0a00 = 240
+0x0a01 = 608
+0x0a02 = 384
+0x0a03 = 512
+0x0a04 = 832
+0x0a05-0x0a0f = Reserved
+0x0a10-0x0aff = Disallowed
+# table A.19 - bitrates for 2nd order HOA coding
+0x0c00 = 192
+0x0c01 = 256
+0x0c02 = 320
+0x0c03 = 384
+0x0c04 = 480
+0x0c05 = 512
+0x0c06 = 640
+0x0c07-0x0c0f = Reserved
+0x0c10-0x0cff = Disallowed
+# table A.20 - bitrates for 3rd order HOA coding
+0x0b00 = 256
+0x0b01 = 320
+0x0b02 = 384
+0x0b03 = 512
+0x0b04 = 640
+0x0b05 = 896
+0x0b06-0x0b0f = Reserved
+0x0b10-0x0bff = Disallowed
+# no bitrate specification for 10.2 coding
+0x0400-0x04ff = 10.2 Unspecified
+# no bitrate specification for 22.2 coding
+0x0500-0x05ff = 22.2 Unspecified
+
+[AVS3_audio_descriptor.bitstream_type]
+Bits = 1
+# T/AI 109.3, Annex A.2
+0 = uniform
+1 = variable

--- a/src/libtsduck/dtv/descriptors/avs/tsAVS3AudioDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVS3AudioDescriptor.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <AVS3_audio_descriptor
+        sampling_frequency_index="uint4, required"
+        resolution="8 bits|16 bits|24 bits, required">
+      
+      <!-- required for audio_codec_id==0 (General High Rate Coding) -->
+      <general_coding
+        coding_profile="basic|object|HOA, required"
+        bitrate_index="uint4, required"
+        bitstream_type="uniform|variable, required"
+        channel_number_index="uint7, required"
+        raw_frame_length="uint16, required">
+      </general_coding>
+
+      <!-- required for audio_codec_id==1 (Lossless Coding) -->
+      <lossless_coding
+        sampling_frequency="uint24, optional"
+        coding_profile="basic|object|HOA, required"
+        channel_number="uint8, required">
+      </lossless_coding>
+
+      <!-- required for audio_codec_id==2 (General Full Rate Coding) -->
+      <fullrate_coding
+        nn_type="uint3, required"
+        channel_num_index="uint7, optional"
+        num_objects="uint7, optional"
+        hoa_order="uint4, optional"
+        total_bitrate="uint16, required"/>
+
+      <additional_info>
+        Hexadecimal content
+      </additional_info>
+      
+    </AVS3_audio_descriptor>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/avs/tsAVS3VideoDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVS3VideoDescriptor.cpp
@@ -18,7 +18,7 @@
 #define MY_XML_NAME u"AVS3_video_descriptor"
 #define MY_CLASS ts::AVS3VideoDescriptor
 #define MY_DID ts::DID_AVS3_VIDEO
-#define MY_PDS ts::PDS_AVS
+#define MY_PDS ts::PDS_AVSVideo
 #define MY_STD ts::Standards::DVB
 
 TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::Private(MY_DID, MY_PDS), MY_XML_NAME, MY_CLASS::DisplayDescriptor);

--- a/src/libtsduck/dtv/descriptors/avs/tsAVSANCDataBlockType.arch-cpp
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVSANCDataBlockType.arch-cpp
@@ -1,0 +1,517 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2024, Paul Higgs
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsAVSANCDataBlockType.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+#include "tsNamesFile.h"
+#include "tsFloatingPoint.h"
+
+#define MY_XML_NAME u"AVS_ANC_data_block"
+
+
+//----------------------------------------------------------------------------
+// Initializers
+//----------------------------------------------------------------------------
+
+const ts::UString ts::anc_data_block_type::ANC_Data_Block_Element_Name(u"anc_data_block");
+
+
+//----------------------------------------------------------------------------
+// Helpers
+//----------------------------------------------------------------------------
+
+// this is a duplicate of the DataName function from AbstractSignalization so we can interrogate the defined names
+template <typename INT, typename std::enable_if<std::is_integral<INT>::value, int>::type = 0>
+static ts::UString DataName(const ts::UChar* xml_name, const ts::UChar* section, INT value, ts::NamesFlags flags = ts::NamesFlags::NAME, size_t bits = 0, INT alternate = 0)
+{
+    return ts::NamesFile::Instance(ts::NamesFile::Predefined::DTV)->nameFromSection(ts::UString::Format(u"%s.%s", xml_name, section), ts::NamesFile::Value(value), flags, bits, ts::NamesFile::Value(alternate));
+}
+
+size_t ts::anc_data_block_type::loudness_metadata_block_type::avs3_loudness::BitsInValue(uint8_t loudnessValueType) const
+{
+    size_t rc = 0;
+    //!< see T/AI 109.7 table B.6
+    switch (loudnessValueType) {
+        case 0:  // unknown loudness type
+        case 1:  // program loudness
+        case 2:  // Anchor loudness
+        case 3:  // Maximum loudness range
+        case 4:  // Maximum instantaneous loudness
+        case 5:  // Maximum short-term loudness
+        case 6:  // Loudness range defined in EBU-R128
+        case 9:  // short-term loudness
+            rc =  8;
+            break;
+        case 7:  // sound pressure level
+            rc = 5;
+            break;
+        case 8:  // create room type
+            rc = 2;
+            break;
+        default:
+            break;
+    }
+    return rc;
+}
+
+
+double ts::anc_data_block_type::loudness_metadata_block_type::avs3_loudness::LoudnessValToRange(uint8_t _loudnessVal)
+{
+    if (_loudnessVal == 0) {
+        return 0.0;
+    }
+    else if (_loudnessVal <= 128) {
+        return double(_loudnessVal) / 4.0;
+    }
+    else if (_loudnessVal <= 204) {
+        return 32.0 + (double(_loudnessVal - 128) / 2.0);
+    }
+    // else _loudnessVal <= 255
+    return (double(_loudnessVal) - 204.5) + 70.0;
+}
+
+
+uint8_t ts::anc_data_block_type::loudness_metadata_block_type::avs3_loudness::LoudnessRangeToVal(double loudnessRange)
+{
+    if (loudnessRange < 0.0) {
+        return 0;
+    }
+    else if (loudnessRange <= 32.0) {
+        return (uint8_t(4.0 * loudnessRange + 0.5));
+    }
+    else if (loudnessRange <= 70.0) {
+        return (uint8_t(2.0 * (loudnessRange - 32.0) + 0.5) + 128);
+    }
+    else if (loudnessRange <= 121.0) {
+        return (uint8_t((loudnessRange - 70.0) + 0.5) + 204);
+    }
+    return 255;
+}
+
+
+double ts::anc_data_block_type::ValueRange(double value, double maxValue, double minRange, double maxRange)
+{
+    using Double = ts::FloatingPoint<double>;
+    static const Double zero(0), _value(value);
+
+    if (minRange > maxRange) {
+        std::swap(minRange, maxRange);
+    }
+    if (_value == zero) {
+        return minRange;
+    }
+    else if (_value == Double(maxValue)) {
+        return maxRange;
+    }
+    const double offset = -minRange;
+    const double maxRange_norm = maxRange + offset;
+    return ((value / maxValue) * maxRange_norm) - offset;
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::anc_data_block_type::object_extension_metadata_block_type::serialize(PSIBuffer& buf) const
+{
+    buf.putBit(objChannelLock_maxDist.has_value());
+    if (objChannelLock_maxDist.has_value()) {
+        buf.putBits(objChannelLock_maxDist.value(), 4);
+    }
+    buf.putBits(objDiffuse, 7);
+    buf.putBits(objGain, 8);
+    buf.putBits(objDivergence, 4);
+    if (objDivergence > 0) {
+        buf.putBits(objDivergencePosRange.value_or(0), 4);
+    }
+    buf.writeRealignByte(1);  // byte_alignment
+}
+
+void ts::anc_data_block_type::loudness_metadata_block_type::avs3_loudness::serialize(PSIBuffer& buf) const
+{
+    buf.putBits(loudnessValDef, 4);
+    const size_t loudnessVal_bits = BitsInValue(loudnessValDef);
+    if (loudnessVal_bits != 0) {
+        buf.putBits(loudnessVal, loudnessVal_bits);
+    }
+}
+
+void ts::anc_data_block_type::loudness_metadata_block_type::serialize(PSIBuffer& buf) const
+{
+    buf.putBit(samplePeakLevel.has_value());  // hasSamplePeakLevel
+    buf.putBits(0xFF, 3);
+    if (samplePeakLevel.has_value()) {
+        buf.putBits(samplePeakLevel.value(), 12);
+    }
+    buf.putBits(truePeakLevel, 12);
+    buf.putBits(loudnessMeasure, 4);
+    buf.putBits(loudnessValues.size(), 4);
+    for (const auto& loud : loudnessValues) {
+        loud.serialize(buf);
+    }
+}
+
+void ts::anc_data_block_type::anc_data_types::serialize(PSIBuffer& buf) const
+{
+    if (std::holds_alternative<object_extension_metadata_block_type>(auxiliary_data)) {
+        buf.putBits(Extended_Object_Metadata, 4);
+        std::get<object_extension_metadata_block_type>(auxiliary_data).serialize(buf);
+    }
+    else if (std::holds_alternative<loudness_metadata_block_type>(auxiliary_data)) {
+        buf.putBits(Loudness_Metadata, 4);
+        std::get<loudness_metadata_block_type>(auxiliary_data).serialize(buf);
+    }
+    else {
+        buf.putBits(Invalid_Metadata, 4); 
+    }
+    buf.writeRealignByte(1);
+}
+
+void ts::anc_data_block_type::serialize(PSIBuffer& buf) const 
+{
+    buf.pushWriteSequenceWithLeadingLength(8);  // start write sequence
+    buf.putBits(anc_block.size(), 4);
+    buf.putBits(0xFF, 4);
+    for (const auto& block : anc_block) {
+        block.serialize(buf);
+    }
+    buf.writeRealignByte(1);
+    buf.popState();  // end write sequence
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::anc_data_block_type::object_extension_metadata_block_type::deserialize(PSIBuffer& buf)
+{
+    // Table 18 of AVS3 Part 7. May be updated by AVS Workgroup of China
+    const bool hasObjChannelLock = buf.getBool();
+    if (hasObjChannelLock) {
+        objChannelLock_maxDist = buf.getBits<uint8_t>(4);
+    }
+    objDiffuse = buf.getBits<uint8_t>(7);
+    objGain = buf.getUInt8();
+    objDivergence = buf.getBits<uint8_t>(4);
+    if (objDivergence > 0) {
+        objDivergencePosRange = buf.getBits<uint8_t>(4);
+    }
+    buf.readRealignByte();
+}
+
+void ts::anc_data_block_type::loudness_metadata_block_type::avs3_loudness::deserialize(PSIBuffer& buf)
+{
+    loudnessValDef = buf.getBits<uint8_t>(4);
+    const size_t loudnessVal_bits = BitsInValue(loudnessValDef);
+    if (loudnessVal_bits != 0) {
+        loudnessVal = buf.getBits<uint8_t>(loudnessVal_bits);
+    }
+}
+
+void ts::anc_data_block_type::loudness_metadata_block_type::deserialize(PSIBuffer& buf)
+{
+    // Table 19 of AVS3 Part 7. May be updated by AVS Workgroup of China
+    const bool hasSamplePeakLevel = buf.getBool();
+    buf.skipBits(3);
+    if (hasSamplePeakLevel) {
+        samplePeakLevel = buf.getBits<uint16_t>(12);
+    }
+    truePeakLevel = buf.getBits<uint16_t>(12);
+    loudnessMeasure = buf.getBits<uint8_t>(4);
+    const uint8_t loudnessValNum = buf.getBits<uint8_t>(4);
+    for (auto i = 0; i < loudnessValNum; i++) {
+        avs3_loudness tmp(buf);
+        loudnessValues.push_back(tmp);
+    }
+}
+
+void ts::anc_data_block_type::anc_data_types::deserialize(PSIBuffer& buf)
+{
+    const uint8_t anc_data_type = buf.getBits<uint8_t>(4);
+    if (anc_data_type == Extended_Object_Metadata) {
+        object_extension_metadata_block_type obj_ext(buf);
+        auxiliary_data = obj_ext;
+    }
+    else if (anc_data_type == Loudness_Metadata) {
+        loudness_metadata_block_type loud(buf);
+        auxiliary_data = loud;
+    }
+    else {
+        auxiliary_data = std::monostate {};
+    }
+    buf.readRealignByte();
+}
+
+void ts::anc_data_block_type::deserialize(PSIBuffer& buf)
+{
+    buf.skipBits(8); // anc_data_length
+    const uint8_t anc_data_number = buf.getBits<uint8_t>(4);
+    buf.skipBits(4);
+    for (auto i = 0; i < anc_data_number; i++) {
+        anc_data_types tmp(buf);
+        anc_block.push_back(tmp);
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display the object.
+//----------------------------------------------------------------------------
+
+void ts::anc_data_block_type::object_extension_metadata_block_type::display(TablesDisplay& disp, const UString& margin)
+{
+    disp << margin << "Maximum Object Channels: " << uint16_t(maxObjChannelNum);
+    if (objChannelLock_maxDist.has_value()) {
+        disp << UString::Format(u", Max Locking Distance: %6.4f", ValueRange(objChannelLock_maxDist.value(), 0x0F, 0, 2*sqrt(3)));
+    }
+    disp << UString::Format(u", Diffuse Reflection: %6.4f", ValueRange(objDiffuse, 0x7F, 0, 1)) << std::endl;
+    disp << margin << UString::Format(u"Gain: %6.4f", ValueRange(objGain, 0xFF, -41, 0))
+         << UString::Format(u", Divergence: %6.4f", ValueRange(objDivergence, 0x0F, 0, 1));
+    if ((objDivergence > 0) && (objDivergencePosRange.has_value())) {
+        disp << UString::Format(u", Divergence Range: %6.4f", ValueRange(objDivergencePosRange.value(), 0x0F, 0, 1));
+    }
+    disp << std::endl;
+}
+
+void ts::anc_data_block_type::loudness_metadata_block_type::avs3_loudness::display(TablesDisplay& disp, const UString& margin, const int index)
+{
+    disp << margin << "[" << index << "] "
+         << DataName(MY_XML_NAME, u"loudness_value_type", loudnessValDef, NamesFlags::VALUE);
+    switch (loudnessValDef) {
+        case 0x0:  // Unknown
+            disp << UString::Format(u": 0x%X", loudnessVal);
+            break;
+        case 0x1:  // Program loudness
+        case 0x2:  // Anchor loudness
+            disp << UString::Format(u": %6.4f (%d)", ValueRange(loudnessVal, pow(2, BitsInValue(loudnessValDef)) - 1, -41, 0), loudnessVal);
+            break;
+        case 0x3:  // Maximum loudness range
+        case 0x4:  // Maximum instantaneous loudness
+        case 0x5:  // Maximum short-term loudness
+            disp << ": " << uint16_t(loudnessVal);
+            break;
+        case 0x6:  // Loudness range defined in EBU-R 128
+            disp << UString::Format(u": %5.2f (%d)", LoudnessValToRange(loudnessVal), loudnessVal);
+            break;
+        case 0x7:  // Sound presssure level
+            disp << UString::Format(u": %6.4f (%d)", 80 + loudnessVal, loudnessVal);
+            break;
+        case 0x8:  // Create room type
+            disp << ": " << DataName(MY_XML_NAME, u"room_type", loudnessVal, NamesFlags::VALUE);
+            break;
+        case 0x9:  // Short-term loudness
+            disp << UString::Format(u": %6.4f (%d)", -116 + (loudnessVal * 0.5), loudnessVal);
+            break;
+        default:
+            disp << UString::Format(u" !! ERROR {0x%x} !!", loudnessValDef);
+            break;
+    }
+    disp << std::endl;
+}
+
+void ts::anc_data_block_type::loudness_metadata_block_type::display(TablesDisplay& disp, const UString& margin)
+{
+    disp << margin << UString::Format(u"True Peak Level: %6.4f (%d)", ValueRange(truePeakLevel, 0xFFF, -107, 20), truePeakLevel);
+    if (samplePeakLevel.has_value()) {
+        disp << UString::Format(u", Sample Peak Level: %6.4f (%d)", ValueRange(samplePeakLevel.value(), 0xFFF, -107, 20), samplePeakLevel.value());
+    }
+    disp << ", Loudness Measure: " << DataName(MY_XML_NAME, u"loudness_measure", loudnessMeasure, NamesFlags::VALUE) << std::endl;
+    int index = 0;
+    for (auto li : loudnessValues) {
+        li.display(disp, margin, index++);
+    }
+}
+
+void ts::anc_data_block_type::anc_data_types::display(TablesDisplay& disp, const UString& margin)
+{
+    if (std::holds_alternative<object_extension_metadata_block_type>(auxiliary_data)) {
+        disp << "Object Extension Metadata" << std::endl;
+        std::get<object_extension_metadata_block_type>(auxiliary_data).display(disp, margin + u"  ");
+    }
+    else if (std::holds_alternative<loudness_metadata_block_type>(auxiliary_data)) {
+        disp << "Loudness Metadata" << std::endl;
+        std::get<loudness_metadata_block_type>(auxiliary_data).display(disp, margin + u"  ");
+     }
+    else {
+        disp << "No Additional Metadata (ERROR)" << std::endl;
+    }
+}
+
+void ts::anc_data_block_type::display(TablesDisplay& disp, const UString& margin)
+{
+    int index = 0;
+    for (auto anc : anc_block) {
+        disp << margin << "ANC[" << index++ << "]: ";
+        anc.display(disp, margin);
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::anc_data_block_type::object_extension_metadata_block_type::toXML(xml::Element* root) const
+{
+    root->setIntAttribute(u"maxObjChannelNum", maxObjChannelNum);
+    root->setOptionalIntAttribute(u"objChannelLock_maxDist", objChannelLock_maxDist);
+    root->setIntAttribute(u"objDiffuse", objDiffuse);
+    root->setIntAttribute(u"objGain", objGain);
+    root->setIntAttribute(u"objDivergence", objDivergence);
+    root->setOptionalIntAttribute(u"objDivergencePosRange", objDivergencePosRange);
+}
+
+void ts::anc_data_block_type::loudness_metadata_block_type::avs3_loudness::toXML(xml::Element* root) const
+{
+    root->setIntAttribute(u"loudnessValDef", loudnessValDef);
+    root->setIntAttribute(u"loudnessVal", loudnessVal);
+}
+
+void ts::anc_data_block_type::loudness_metadata_block_type::toXML(xml::Element* root) const
+{
+    root->setOptionalIntAttribute(u"samplePeakLevel", samplePeakLevel);
+    root->setIntAttribute(u"truePeakLevel", truePeakLevel);
+    root->setIntAttribute(u"loudnessMeasure", loudnessMeasure);
+    for (auto l : loudnessValues) {
+        l.toXML(root->addElement(u"loudnessValue"));
+    }
+}
+
+void ts::anc_data_block_type::anc_data_types::toXML(xml::Element* root) const
+{
+    if (std::holds_alternative<object_extension_metadata_block_type>(auxiliary_data)) {
+        std::get<object_extension_metadata_block_type>(auxiliary_data).toXML(root->addElement(u"object_extension_metadata_block"));
+    }
+    else if (std::holds_alternative<loudness_metadata_block_type>(auxiliary_data)) {
+        std::get<loudness_metadata_block_type>(auxiliary_data).toXML(root->addElement(u"loudness_metadata_block"));
+    }
+}
+
+void ts::anc_data_block_type::toXML(xml::Element* root) const
+{
+    for (auto anc : anc_block) {
+        anc.toXML(root->addElement(u"anc_data_block"));
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::anc_data_block_type::object_extension_metadata_block_type::fromXML(const xml::Element* element)
+{
+    bool ok = element->getOptionalIntAttribute(objChannelLock_maxDist, u"objChannelLock_maxDist", 0, 0xF) &&
+              element->getIntAttribute(objDiffuse, u"objDiffuse", true, 0, 0, 127) &&
+              element->getIntAttribute(objGain, u"objGain", true) &&
+              element->getIntAttribute(objDivergence, u"objDivergence", true, 0, 0, 0xF);
+    if (ok && (objDivergence > 0)) {
+        if (element->hasAttribute(u"objDivergencePosRange")) {
+            ok = element->getOptionalIntAttribute(objDivergencePosRange, u"objDivergencePosRange", 0, 0xF);
+        }
+        else {
+            element->report().error(u"objDivergencePosRange is required when objDivergencePosRange > 0 in <%s>, line %d", element->name(), element->lineNumber());
+            ok = false;
+        }
+    }
+    return ok;
+}
+
+bool ts::anc_data_block_type::loudness_metadata_block_type::avs3_loudness::fromXML(const xml::Element* element)
+{
+    bool ok = element->getIntAttribute(loudnessValDef, u"loudnessValDef", true, 0, 0, 0x0f);
+    if (ok) {
+        if (loudnessValDef > 9) {
+            element->report().error(u"invalid value for loudnessValDef (see Table B.7 of T/AI 109.7) in <%s>, line %d", element->name(), element->lineNumber());
+            ok = false;
+        }
+    }
+    if (ok) {
+        size_t loudnessValBits = BitsInValue(loudnessValDef);
+        ok = element->getIntAttribute(loudnessVal, u"loudnessVal", true, 0, 0, pow(2, loudnessValBits) - 1);
+    }
+    return ok;
+}
+
+bool ts::anc_data_block_type::loudness_metadata_block_type::fromXML(const xml::Element* element)
+{
+    xml::ElementVector loudnessVals;
+    bool ok = element->getOptionalIntAttribute(samplePeakLevel, u"samplePeakLevel", 0, 0x0fff) &&
+              element->getIntAttribute(truePeakLevel, u"truePeakLevel", true, 0, 0, 0x0fff) &&
+              element->getIntAttribute(loudnessMeasure, u"loudnessMeasure", 0, 0xf) &&
+              element->getChildren(loudnessVals, u"loudnessValue", 0, 15);
+
+    if (ok && !loudnessVals.empty()) {
+        for (auto lv : loudnessVals) {
+            avs3_loudness l;
+            if (l.fromXML(lv)) {
+                loudnessValues.push_back(l);
+            }
+            else {
+                ok = false;
+            }
+        }
+    }
+    return ok;
+}
+
+bool ts::anc_data_block_type::anc_data_types::fromXML(const xml::Element* element)
+{
+    bool               ok = true;
+    xml::ElementVector children;
+    if (element->hasChildElement(u"object_extension_metadata_block") && element->hasChildElement(u"loudness_metadata_block")) {
+        element->report().error(u"cannot specify both <object_extension_metadata_block> and <loudness_metadata_block> in <%s>, line %d", element->name(), element->lineNumber());
+        ok = false;
+    }
+    else if (element->hasChildElement(u"object_extension_metadata_block")) {
+        ok = element->getChildren(children, u"object_extension_metadata_block", 1, 1);
+        object_extension_metadata_block_type oem;
+        if (ok && oem.fromXML(children[0])) {
+            auxiliary_data = oem;
+        }
+        else {
+            ok = false;
+        }
+    }
+    else if (element->hasChildElement(u"loudness_metadata_block")) {
+        ok = element->getChildren(children, u"loudness_metadata_block", 1, 1);
+        loudness_metadata_block_type lm;
+        if (ok && lm.fromXML(children[0])) {
+            auxiliary_data = lm;
+        }
+        else {
+            ok = false;
+        }
+    }
+    else {
+        element->report().error(u"neither <object_extension_metadata_block> or <loudness_metadata_block> are specified in <%s>, line %d", element->name(), element->lineNumber());
+        auxiliary_data = std::monostate {};
+        ok = false;
+    }
+    return ok;
+}
+
+bool ts::anc_data_block_type::fromXML(const xml::ElementVector elements)
+{
+    bool ok = true;
+    for (auto anc : elements) {
+        anc_data_types oneANC;
+        if (oneANC.fromXML(anc)) {
+            anc_block.push_back(oneANC);
+        }
+        else {
+            ok = false;
+        }
+    }
+    return ok;
+}

--- a/src/libtsduck/dtv/descriptors/avs/tsAVSANCDataBlockType.arch-h
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVSANCDataBlockType.arch-h
@@ -1,0 +1,223 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2024, Paul Higgs
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of an ANC data block used by the AVS2_audio_descriptor and
+//!  the AVS3_audio_descriptor
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include <variant>
+#include "tsPlatform.h"
+#include "tsPSIBuffer.h"
+#include "tsTablesDisplay.h"
+#include "tsxmlElement.h"
+#include "tsByteBlock.h"
+
+namespace ts {
+    //!
+    //! Representation of an anc_data_block.
+    //!
+    //! @see Appendix B of T/AI 109.7.
+    //!
+    class TSDUCKDLL anc_data_block_type
+    {
+    public:
+        //!
+        //! object extension carries in an auxiliary data block
+        //! 
+       class TSDUCKDLL object_extension_metadata_block_type
+       {
+        public:
+            uint8_t                maxObjChannelNum = 0;       //!< the maximum number of channel objects
+            std::optional<uint8_t> objChannelLock_maxDist {};  //!< 4 bits. maximum channel locking distance
+            uint8_t                objDiffuse = 0;             //!< 7 bits. diffuse reflection of the object
+            uint8_t                objGain = 0;                //!< loudness informatoin of the object
+            uint8_t                objDivergence = 0;          //!< 4 bits. dispersion degree of an object
+            std::optional<uint8_t> objDivergencePosRange {};   //!< 4 bits. balance betwee the specified position of the object and other two positions.
+
+            //!
+            //! Default constructor
+            //!
+            object_extension_metadata_block_type() = default;
+
+            //!
+            //! Read-in constructor.
+            //! @param [in,out] buf Deserialization buffer.
+            //!
+            object_extension_metadata_block_type(PSIBuffer& buf) :
+                object_extension_metadata_block_type() { deserialize(buf); }
+
+            //! @cond nodoxygen
+            // Delegated methods.
+            void serialize(PSIBuffer& buf) const;
+            void deserialize(PSIBuffer& buf);
+            bool fromXML(const xml::Element* element);
+            void toXML(xml::Element* root) const;
+            void display(ts::TablesDisplay& display, const ts::UString& margin);
+            //! @endcond
+        };
+
+        //!
+        //! object extension carries in an auxiliary data block
+        //! 
+        class TSDUCKDLL loudness_metadata_block_type
+        {
+        public:
+            //!
+            //! depiction of an AVS audio loudness type and value
+            //! 
+            class TSDUCKDLL avs3_loudness
+            {
+            public:
+                uint8_t loudnessValDef = 0;  //!< 4 bits. The type of loudness value being provided.
+                uint8_t loudnessVal = 0;     //!< 2..8 bits. The loudness value.
+
+                //!
+                //! Default constructor
+                //!
+                avs3_loudness() = default;
+
+                //!
+                //! Read-in constructor.
+                //! @param [in,out] buf Deserialization buffer.
+                //!
+                avs3_loudness(PSIBuffer& buf) : avs3_loudness() { deserialize(buf); }
+
+                //! @cond nodoxygen
+                // Delegated methods.
+                void serialize(PSIBuffer& buf) const;
+                void deserialize(PSIBuffer& buf);
+                bool fromXML(const xml::Element* element);
+                void toXML(xml::Element* root) const;
+                void display(ts::TablesDisplay& display, const ts::UString& margin, const int index);
+                //! @endcond
+
+                //!
+                //! gives the number of bits for the value type
+                //! @param [in] loudnessValueType  the type of loudness value being expressed
+                //! @returns the number of bits to use when storing the loudness value in a binary notation
+                //! 
+                size_t BitsInValue(uint8_t loudnessValueType) const;
+
+                //!
+                //! Given a loudness value for loudnessValDef==6 (EBU R 128), calculate the loudness value
+                //! This is the inversion of the algirithm provided in Table B.8 of T/AI 109.7
+                //! @param [in] loudnessVal a binary (0..255) loudness value
+                //! @returns an EBU R 128 loudness range 
+                //! 
+                double LoudnessValToRange(uint8_t loudnessVal);
+
+                //!
+                //! Convert a loudnessRange to a loudnessVal for serialization. See Table B.8 of T/AI 109.7
+                //! @param [in] loudnessRange an EBU R 128 loudness value
+                //! @return a binary (0..255) loudness value
+                //! 
+                uint8_t LoudnessRangeToVal(double loudnessRange);
+            };
+
+            std::optional<uint16_t>    samplePeakLevel {};   //!< 12 bits. the highest instantaneous level of the digital audio samples
+            uint16_t                   truePeakLevel = 0;    //!< 12 bits. value of the audio signal waveform in the continuous time domain
+            uint8_t                    loudnessMeasure = 0;  //!< 4 bits. Loudness measurement method description
+            std::vector<avs3_loudness> loudnessValues {};    //!< the diffeent loudness values
+
+            //!
+            //! Default constructor
+            //!
+            loudness_metadata_block_type() = default;
+
+            //!
+            //! Read-in constructor.
+            //! @param [in,out] buf Deserialization buffer.
+            //!
+            loudness_metadata_block_type(PSIBuffer& buf) : loudness_metadata_block_type() { deserialize(buf); }
+
+            //! @cond nodoxygen
+            // Delegated methods.
+            void serialize(PSIBuffer& buf) const;
+            void deserialize(PSIBuffer& buf);
+            bool fromXML(const xml::Element* element);
+            void toXML(xml::Element* root) const;
+            void display(ts::TablesDisplay& display, const ts::UString& margin);
+            //! @endcond
+        };
+
+        //!
+        //! A container for the different types which can be carried in an auxiliary data block
+        //! 
+        class TSDUCKDLL anc_data_types
+        {
+        public:
+            std::variant<std::monostate, object_extension_metadata_block_type, loudness_metadata_block_type> auxiliary_data {};  //!< anc block data
+ 
+            //!
+            //! Default constructor
+            //! 
+            anc_data_types() = default;
+
+            //!
+            //! Read-in constructor.
+            //! @param [in,out] buf Deserialization buffer.
+            //!
+            anc_data_types(PSIBuffer& buf) : anc_data_types() { deserialize(buf); }
+
+            //! @cond nodoxygen
+            // Delegated methods.
+            void serialize(PSIBuffer& buf) const;
+            void deserialize(PSIBuffer& buf);
+            bool fromXML(const xml::Element* element);
+            void toXML(xml::Element* root) const;
+            void display(ts::TablesDisplay& display, const ts::UString& margin);
+            //! @endcond
+
+            static constexpr uint8_t Invalid_Metadata = 0;          //!< unsupported auxiliary data type
+            static constexpr uint8_t Extended_Object_Metadata = 1;  //!< auxiliary data type is object metadata
+            static constexpr uint8_t Loudness_Metadata = 2;         //!< auxiliary data type is loudness metadata
+        };
+
+        //! auxiliary information blocks containing either object extension metadata or loudness metadata
+        std::vector<anc_data_types> anc_block {};   
+
+        //!
+        //! Default constructor
+        //! 
+        anc_data_block_type() = default;
+
+        //!
+        //! Read-in constructor.
+        //! @param [in,out] buf Deserialization buffer.
+        //!
+        anc_data_block_type(PSIBuffer& buf) :
+            anc_data_block_type() { deserialize(buf); }
+
+        //! @cond nodoxygen
+        // Delegated methods.
+        void serialize(PSIBuffer& buf) const;
+        void deserialize(PSIBuffer& buf);
+        bool fromXML(const xml::ElementVector elements);
+        void toXML(xml::Element* root) const;
+        void display(ts::TablesDisplay& display, const ts::UString& margin);
+        //! @endcond
+
+        //!
+        //! Translate the \p value into the range \p minRange .. \p maxRange
+        //! @param [in] value the value to be mapped into the range, zero based
+        //! @param [in] maxValue the maximum value of \p value - normally based on the number of bits
+        //! @param [in] minRange the lowest value in the range, when \p value = 0
+        //! @param [in] maxRange the highest value in the range, when \p value = \p maxValue
+        //! @returns the value when mapped into a range of values
+        //! 
+        static double ValueRange(double value, double maxValue, double minRange, double maxRange);
+
+        friend class AVS3AudioDescriptor;
+        friend class AVS2AudioDescriptor;
+
+        static const UString ANC_Data_Block_Element_Name;  //!< element name to use in XML
+    };
+}

--- a/src/libtsduck/dtv/descriptors/avs/tsAVSANCDataBlockType.arch-names
+++ b/src/libtsduck/dtv/descriptors/avs/tsAVSANCDataBlockType.arch-names
@@ -1,0 +1,34 @@
+[AVS_ANC_data_block.loudness_measure]
+Bits = 4
+# T/AI 109.3,table B.5
+0x0 = Unknown
+0x1 = EBU-R 128
+0x2 = ITU-R BS.1770-4
+0x3 = ITU-R BS.1770-4 with preprocessing
+0x4 = User (personalised)
+0x5 = Expert/Panel (preset)
+0x6 = ITU-R BS.1771-1
+0x7-0xF = Reserved
+
+[AVS_ANC_data_block.loudness_value_type]
+Bits = 4
+# T/AI 109.3,table B.6
+0x0 = Unknown loudness type
+0x1 = Program loudness
+0x2 = Anchor loudness
+0x3 = Maximum loudness range
+0x4 = Maximum instantaneous loudness
+0x5 = Maximum short-term loudness
+0x6 = According to EBU-R 128
+0x7 = Sound pressure level
+0x8 = Create room type
+0x9 = Short-term loudness
+0xA-0xF = Reserved
+
+[AVS_ANC_data_block.room_type]
+Bits = 2
+# T/AI 109.3,table B.7
+0 = Unknown
+1 = Large room, curved screen
+2 = Small room, flat screen
+3 = Reserved

--- a/src/libtsduck/dtv/signalization/tsPSI.cpp
+++ b/src/libtsduck/dtv/signalization/tsPSI.cpp
@@ -36,7 +36,8 @@ const ts::Enumeration ts::PrivateDataSpecifierEnum({
     {u"Eutelsat",  ts::PDS_EUTELSAT},
     {u"OFCOM",     ts::PDS_OFCOM},
     {u"Australia", ts::PDS_AUSTRALIA},
-    {u"AVS",       ts::PDS_AVS},
+    {u"AVSV",      ts::PDS_AVSVideo},
+    {u"AVSA",      ts::PDS_AVSAudio},
     {u"AOM",       ts::PDS_AOM},
     {u"cuvv",      ts::PDS_CUVV},
 });

--- a/src/libtsduck/dtv/signalization/tsPSI.h
+++ b/src/libtsduck/dtv/signalization/tsPSI.h
@@ -315,7 +315,8 @@ namespace ts {
         PDS_AUSTRALIA = 0x00003200, //!< Private data specifier for Free TV Australia.
         PDS_AOM       = 0x414F4D53, //!< Private data specifier for the Alliance for Open Media (AOM) (value is "AOMS" in ASCII).
         PDS_ATSC      = 0x41545343, //!< Fake private data specifier for ATSC descriptors (value is "ATSC" in ASCII).
-        PDS_AVS       = 0x41565356, //!< Private data specifier for AVS Working Group of China (value is "AVSV" in ASCII).
+        PDS_AVSAudio  = 0x41565341, //!< Private data specifier for AVS Working Group of China (value is "AVSA" in ASCII).
+        PDS_AVSVideo  = 0x41565356, //!< Private data specifier for AVS Working Group of China (value is "AVSV" in ASCII).
         PDS_ISDB      = 0x49534442, //!< Fake private data specifier for ISDB descriptors (value is "ISDB" in ASCII).
         PDS_CUVV      = 0x63757676, //!< Private data specifier for UHD World Association (value is "cuvv" in ASCII).
         PDS_NULL      = 0xFFFFFFFF, //!< An invalid private data specifier, can be used as placeholder.
@@ -657,9 +658,14 @@ namespace ts {
         DID_LOGICAL_CHANNEL_SKY = 0xB1, //!< DID for BskyB logical_channel_number_by_region_descriptor
         DID_SERVICE_SKY         = 0xB2, //!< DID for BskyB service_descriptor
 
-        // Valid in DVB context after PDS_AVS private_data_specifier
+        // Valid in DVB context after PDS_AVSVideo private_data_specifier
 
         DID_AVS3_VIDEO          = 0xD1, //!< DID for AVS3 video descriptor, as defined in T/AI 109.6
+
+        // Valid in DVB context after PDS_AVSAudio private_data_specifier
+
+        DID_AVS3_AUDIO          = 0xD2,  //!< DID for AVS3 audio descriptor, as defined in T/AI 109.7
+        DID_AVS2_AUDIO          = 0xD3,  //!< DID for AVS2 audio descriptor, as defined in T/AI 109.7 
 
         // Valid in DVB context after PDS_CUVV private_data_specifier
 

--- a/src/libtsduck/dtv/signalization/tsPSI.names
+++ b/src/libtsduck/dtv/signalization/tsPSI.names
@@ -315,7 +315,8 @@ Bits = 32
 0x414F4D53 = AOM
 0x41545343 = ATSC (fake PDS for ATSC descriptors)
 0x41555300 = Foxtel Management
-0x41565356 = AVS
+0x41565341 = AVS Audio
+0x41565356 = AVS Video
 0x44414E59 = NDS
 0x46524549 = NDS
 0x46534154 = BBC
@@ -716,7 +717,11 @@ Bits = 8
 0x41545343_AB = ATSC Genre
 0x41545343_AD = ATSC Private Information
 0x41545343_CC = ATSC E-AC-3 Audio Stream
-# With PDS for AVS.
+# With PDS for AVS audio.
+# Descriptors are defined by the AVS Working Group of China.
+0x41565341_D2 = AVS3 Audio (T/AI 109.7)
+0x41565341_D3 = AVS2 Audio (T/AI 109.7)
+# With PDS for AVS video.
 # Descriptors are defined by the AVS Working Group of China.
 0x41565356_D1 = AVS3 Video (T/AI 109.6)
 # ISDB descriptors, using the fake PDS for ISDB.

--- a/src/libtsduck/dtv/tables/mpeg/tsPMT.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsPMT.cpp
@@ -347,8 +347,13 @@ ts::CodecType ts::PMT::Stream::getCodec(const DuckContext& duck) const
                 case DID_VBI_TELETEXT:
                     return CodecType::TELETEXT;
                 case DID_AVS3_VIDEO:
-                    if (pds == PDS_AVS) {
-                        return CodecType::AVS3;
+                    if (pds == PDS_AVSVideo) {
+                        return CodecType::AVS3_VIDEO;
+                    }
+                    break;
+                case DID_AVS3_AUDIO:
+                    if (pds == PDS_AVSAudio) {
+                        return CodecType::AVS3_AUDIO;
                     }
                     break;
                 case DID_MPEG_EXTENSION: {


### PR DESCRIPTION
These descriptors indicate the characteristics of AVS2 and AVS3 coded audio in an elementary stream. They are defined in T/AI 109/7
