### PR TITLE
CC counter: add option to show PID in decimal format

### DIFF
--- a/src/libtsduck/dtv/analysis/tsContinuityAnalyzer.cpp
+++ b/src/libtsduck/dtv/analysis/tsContinuityAnalyzer.cpp
@@ -148,7 +148,11 @@ size_t ts::ContinuityAnalyzer::MissingPackets(int cc1, int cc2)
 
 ts::UString ts::ContinuityAnalyzer::linePrefix(PID pid) const
 {
-    return UString::Format(u"%spacket index: %'d, PID: 0x%04X", _prefix, _total_packets, pid);
+    if (_pid_decimal) {
+      return UString::Format(u"%spacket index: %'d, PID: %d", _prefix, _total_packets, pid);
+    } else {
+   	 return UString::Format(u"%spacket index: %'d, PID: 0x%04X", _prefix, _total_packets, pid);
+    }
 }
 
 

--- a/src/libtsduck/dtv/analysis/tsContinuityAnalyzer.h
+++ b/src/libtsduck/dtv/analysis/tsContinuityAnalyzer.h
@@ -161,7 +161,14 @@ namespace ts {
         //! @param [in] pid_filter The list of PID's to process.
         //!
         void setPIDFilter(const PIDSet& pid_filter);
-
+        
+        //!
+        //! Specify log PID in decimal format.
+        //! @param [in] PID logged in decimal format When true.
+        //!
+        void setPIDdec(bool pid_dec) { _pid_decimal = pid_dec; }  
+      
+        
         //!
         //! Add one PID to process.
         //! @param [in] pid The new PID to process.
@@ -261,6 +268,7 @@ namespace ts {
         bool          _replicate_dup = true;      // With _fix_errors, replicate duplicate packets.
         bool          _generator = false;         // Use generator mode.
         bool          _json = false;              // Log JSON messages.
+	bool	      _pid_decimal = false;           // Log PID is decimal format
         UString       _prefix {};                 // Message prefix.
         PacketCounter _total_packets = 0;         // Total number of packets.
         PacketCounter _processed_packets = 0;     // Number of processed packets.

--- a/src/libtsduck/dtv/analysis/tsContinuityAnalyzer.h
+++ b/src/libtsduck/dtv/analysis/tsContinuityAnalyzer.h
@@ -164,7 +164,7 @@ namespace ts {
         
         //!
         //! Specify log PID in decimal format.
-        //! @param [in] PID logged in decimal format When true.
+        //! @param [in]  pid_dec logged in decimal format When true.
         //!
         void setPIDdec(bool pid_dec) { _pid_decimal = pid_dec; }  
       

--- a/src/tsplugins/tsplugin_continuity.cpp
+++ b/src/tsplugins/tsplugin_continuity.cpp
@@ -35,6 +35,7 @@ namespace ts {
         bool    _fix = false;                 // Fix incorrect continuity counters
         bool    _no_replicate = false;        // Option --no-replicate-duplicated
         bool    _json_line = false;           // Use JSON log style.
+	bool	_pid_dec = false;	      // Log PID in decimal format
         UString _json_prefix {};              // Prefix before JSON line.
         int     _log_level = Severity::Info;  // Log level for discontinuity messages
         PIDSet  _pids {};                     // PID values to check or fix
@@ -57,6 +58,10 @@ ts::ContinuityPlugin::ContinuityPlugin(TSP* tsp_) :
     option(u"fix", 'f');
     help(u"fix",
          u"Fix incorrect continuity counters. By default, only display discontinuities.");
+    
+    option(u"pid_dec", 'd');
+    help(u"pid_dec",
+         u"Log PID in decimal format");
 
     option(u"json-line", 0, Args::STRING, 0, 1, 0, Args::UNLIMITED_VALUE, true);
     help(u"json-line", u"'prefix'",
@@ -97,6 +102,7 @@ bool ts::ContinuityPlugin::getOptions()
     getValue(_json_prefix, u"json-line");
     _json_line = present(u"json-line");
     _fix = present(u"fix");
+    _pid_dec = present(u"pid_dec");
     _no_replicate = present(u"no-replicate-duplicated");
     _tag = value(u"tag");
     if (!_tag.empty()) {
@@ -127,6 +133,7 @@ bool ts::ContinuityPlugin::start()
     _cc_analyzer.setMessagePrefix(_json_line ? _json_prefix : _tag);
     _cc_analyzer.setMessageSeverity(_log_level);
     _cc_analyzer.setFix(_fix);
+    _cc_analyzer.setPIDdec(_pid_dec);
     _cc_analyzer.setReplicateDuplicated(!_no_replicate);
     return true;
 }


### PR DESCRIPTION
#### Affected components:
src/libtsduck/dtv/analysis/tsContinuityAnalyzer.cpp
src/libtsduck/dtv/analysis/tsContinuityAnalyzer.h
src/tsplugins/tsplugin_continuity.cpp

#### Brief description of the proposed changes:
added an option to show PID in decimal format on the output