### PR TITLE
Small updates related to AVS codecs and codec types

### DIFF
--- a/src/libtsduck/dtv/codec/tsCodecType.cpp
+++ b/src/libtsduck/dtv/codec/tsCodecType.cpp
@@ -83,39 +83,27 @@ const ts::Enumeration ts::CodecTypeArgEnum({
 
 bool ts::CodecTypeIsAudio(CodecType ct)
 {
-    switch (ct) {
-        case CodecType::MPEG1_AUDIO:
-        case CodecType::MPEG2_AUDIO:
-        case CodecType::MP3:
-        case CodecType::AAC:
-        case CodecType::AC3:
-        case CodecType::EAC3:
-        case CodecType::AC4:
-        case CodecType::HEAAC:
-        case CodecType::DTS:
-        case CodecType::DTSHD:
-        case CodecType::AVS2_AUDIO:
-        case CodecType::AVS3_AUDIO:
-            return true;
+    const std::set<ts::CodecType> AudioCodecs {
+        ts::CodecType::MPEG1_AUDIO,
+        ts::CodecType::MPEG2_AUDIO,
+        ts::CodecType::MP3,
+        ts::CodecType::AAC,
+        ts::CodecType::AC3,
+        ts::CodecType::EAC3,
+        ts::CodecType::AC4,
+        ts::CodecType::HEAAC,
+        ts::CodecType::DTS,
+        ts::CodecType::DTSHD,
+        ts::CodecType::AVS2_AUDIO,
+        ts::CodecType::AVS3_AUDIO,
+    };
 
-        case CodecType::UNDEFINED:
-        case CodecType::MPEG1_VIDEO:
-        case CodecType::MPEG2_VIDEO:
-        case CodecType::MPEG4_VIDEO:
-        case CodecType::J2K:
-        case CodecType::AVC:
-        case CodecType::HEVC:
-        case CodecType::VVC:
-        case CodecType::EVC:
-        case CodecType::LCEVC:
-        case CodecType::VP9:
-        case CodecType::AV1:
-        case CodecType::TELETEXT:
-        case CodecType::DVB_SUBTITLES:
-        case CodecType::AVS3_VIDEO:
-        default:
-            return false;
-    }
+    return
+        #ifdef TS_CXX17
+            AudioCodecs.find(ct) != AudioCodecs.end();
+        #else
+            AudioCodecs.contains(ct);
+        #endif
 }
 
 
@@ -123,41 +111,30 @@ bool ts::CodecTypeIsAudio(CodecType ct)
 // Check if a codec type value indicates a video stream.
 //----------------------------------------------------------------------------
 
+
 bool ts::CodecTypeIsVideo(CodecType ct)
 {
-    switch (ct) {
-        case CodecType::MPEG1_VIDEO:
-        case CodecType::MPEG2_VIDEO:
-        case CodecType::MPEG4_VIDEO:
-        case CodecType::J2K:
-        case CodecType::AVC:
-        case CodecType::HEVC:
-        case CodecType::VVC:
-        case CodecType::EVC:
-        case CodecType::LCEVC:
-        case CodecType::VP9:
-        case CodecType::AV1:
-        case CodecType::AVS3_VIDEO:
-            return true;
+    const std::set<ts::CodecType> VideoCodecs {
+        ts::CodecType::MPEG1_VIDEO,
+        ts::CodecType::MPEG2_VIDEO,
+        ts::CodecType::MPEG4_VIDEO,
+        ts::CodecType::J2K,
+        ts::CodecType::AVC,
+        ts::CodecType::HEVC,
+        ts::CodecType::VVC,
+        ts::CodecType::EVC,
+        ts::CodecType::LCEVC,
+        ts::CodecType::VP9,
+        ts::CodecType::AV1,
+        ts::CodecType::AVS3_VIDEO,
+    };
 
-        case CodecType::UNDEFINED:
-        case CodecType::MPEG1_AUDIO:
-        case CodecType::MPEG2_AUDIO:
-        case CodecType::MP3:
-        case CodecType::AAC:
-        case CodecType::AC3:
-        case CodecType::EAC3:
-        case CodecType::AC4:
-        case CodecType::HEAAC:
-        case CodecType::DTS:
-        case CodecType::DTSHD:
-        case CodecType::TELETEXT:
-        case CodecType::DVB_SUBTITLES:
-        case CodecType::AVS2_AUDIO:
-        case CodecType::AVS3_AUDIO:
-        default:
-            return false;
-    }
+    return
+        #ifdef TS_CXX17
+            VideoCodecs.find(ct) != VideoCodecs.end();
+        #else
+            VideoCodecs.contains(ct);
+        #endif
 }
 
 
@@ -167,39 +144,17 @@ bool ts::CodecTypeIsVideo(CodecType ct)
 
 bool ts::CodecTypeIsSubtitles(CodecType ct)
 {
-    switch (ct) {
-        case CodecType::TELETEXT:
-        case CodecType::DVB_SUBTITLES:
-            return true;
+    const std::set<ts::CodecType> SubtitlingTypes {
+        ts::CodecType::TELETEXT,
+        ts::CodecType::DVB_SUBTITLES,
+    };
 
-        case CodecType::UNDEFINED:
-        case CodecType::MPEG1_VIDEO:
-        case CodecType::MPEG1_AUDIO:
-        case CodecType::MPEG2_VIDEO:
-        case CodecType::MPEG2_AUDIO:
-        case CodecType::MP3:
-        case CodecType::AAC:
-        case CodecType::AC3:
-        case CodecType::EAC3:
-        case CodecType::AC4:
-        case CodecType::MPEG4_VIDEO:
-        case CodecType::HEAAC:
-        case CodecType::J2K:
-        case CodecType::AVC:
-        case CodecType::HEVC:
-        case CodecType::VVC:
-        case CodecType::EVC:
-        case CodecType::LCEVC:
-        case CodecType::VP9:
-        case CodecType::AV1:
-        case CodecType::DTS:
-        case CodecType::DTSHD:
-        case CodecType::AVS3_VIDEO:
-        case CodecType::AVS2_AUDIO:
-        case CodecType::AVS3_AUDIO:
-        default:
-            return false;
-    }
+    return
+        #ifdef TS_CXX17
+            SubtitlingTypes.find(ct) != SubtitlingTypes.end();
+        #else
+            SubtitlingTypes.contains(ct);
+        #endif
 }
 
 

--- a/src/libtsduck/dtv/signalization/tsPSI.cpp
+++ b/src/libtsduck/dtv/signalization/tsPSI.cpp
@@ -77,7 +77,8 @@ bool ts::StreamTypeIsVideo(uint8_t st)
            StreamTypeIsVVC(st)    ||
            st == ST_JPEG_XS_VIDEO ||
            st == ST_EVC_VIDEO     ||
-           st == ST_LCEVC_VIDEO;
+           st == ST_LCEVC_VIDEO   ||
+           st == ST_AVS3_VIDEO;
 }
 
 
@@ -155,7 +156,9 @@ bool ts::StreamTypeIsAudio(uint8_t st, uint32_t regid)
            st == ST_EAC3_AUDIO       ||
            st == ST_MPEG4_AUDIO_RAW  ||
            st == ST_MPH3D_MAIN       ||
-           st == ST_MPH3D_AUX;
+           st == ST_MPH3D_AUX        ||
+           st == ST_AVS2_AUDIO       ||
+           st == ST_AVS3_AUDIO;
 }
 
 

--- a/src/libtsduck/dtv/signalization/tsPSI.h
+++ b/src/libtsduck/dtv/signalization/tsPSI.h
@@ -867,6 +867,8 @@ namespace ts {
         REGID_HEVC = 0x48455643, //!< "HEVC" registration identifier.
         REGID_KLVA = 0x4B4C5641, //!< "KLVA" registration identifier.
         REGID_SCTE = 0x53435445, //!< "SCTE" registration identifier.
+        REGID_AVSA = 0x4A565341, //!< AVS "AVSA" registration identifier.
+        REGID_AVSV = 0x4A565356, //!< AVS "AVSV" registration identifier.
         REGID_NULL = 0xFFFFFFFF, //!< Unassigned registration identifier.
     };
 
@@ -941,7 +943,6 @@ namespace ts {
         ST_EAC3_AUDIO       = 0x87, //!< Enhanced-AC-3 Audio (ATSC only)
         ST_A52B_AC3_AUDIO   = 0x91, //!< A52b/AC-3 Audio
         ST_MS_VIDEO         = 0xA0, //!< MSCODEC Video
-        ST_AVS3             = 0xD4, //!< AVS3 video
         ST_VC1              = 0xEA, //!< Private ES (VC-1)
 
         // Valid after a "HDMV" registration descriptor.
@@ -961,6 +962,12 @@ namespace ts {
         ST_SDDS_AUDIO       = 0x94, //!< SDDS Audio
         ST_HDMV_AC3_PLS_SEC = 0xA1, //!< HDMV AC-3+ Secondary Audio
         ST_DTS_HD_SEC       = 0xA2, //!< DTS-HD Secondary Audio
+
+        // Valid after an appropriate AVS registration descriptor.
+
+        ST_AVS2_AUDIO       = 0xD3, //!< AVS2 audio
+        ST_AVS3_VIDEO       = 0xD4, //!< AVS3 video
+        ST_AVS3_AUDIO       = 0xD5, //!< AVS3 audio
     };
 
     //!

--- a/src/libtsduck/dtv/signalization/tsPSI.names
+++ b/src/libtsduck/dtv/signalization/tsPSI.names
@@ -928,7 +928,6 @@ Bits = 8
 # 0xCF = C+ CMPT (CMPS scenario)
 # 0xD0 = C+ Appli loader
 0xA0 = MSCODEC Video
-0xD4 = AVS3 video
 0xEA = Private ES (VC-1)
 # With HDMV registration id.
 0x48444D56_80 = LPCM Audio
@@ -946,6 +945,13 @@ Bits = 8
 0x48444D56_94 = SDDS Audio
 0x48444D56_A1 = HDMV AC-3+ Secondary Audio
 0x48444D56_A2 = DTS-HD Secondary Audio
+# These could be used in the context of an appropriate AVS registration id, but these values are currently unused in the industry
+0xD3 = AVS2 audio
+0x41565341_D3 = AVS2 audio
+0xD4 = AVS3 video
+0x41565356_D4 = AVS3 video
+0xD5 = AVS3 audio
+0x41565341_D5 = AVS5 audio
 
 [RunningStatus]
 Bits = 3


### PR DESCRIPTION
Couple of updates for AVS2/AVS3 codecs relate to checking content type
Update to use a set lookup, rather than a large switch statement to determine Audio/Video/Subtitling
