### PR TITLE
use defined constants for full length and short length modified Julian dates

### DIFF
--- a/src/libtsduck/dtv/descriptors/dvb/tsCPCMDeliverySignallingDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsCPCMDeliverySignallingDescriptor.cpp
@@ -173,8 +173,8 @@ void ts::CPCMDeliverySignallingDescriptor::CPCMv1Signalling::deserializePayload(
     disable_analogue_hd_consumption = buf.getBool();
     image_constraint = buf.getBool();
     if (view_window_activated) {
-        view_window_start = buf.getMJD(5);
-        view_window_end = buf.getMJD(5);
+        view_window_start = buf.getMJD(MJD_SIZE);
+        view_window_end = buf.getMJD(MJD_SIZE);
     }
     if (view_period_activated) {
         view_period_from_first_playback = buf.getUInt16();
@@ -186,7 +186,7 @@ void ts::CPCMDeliverySignallingDescriptor::CPCMv1Signalling::deserializePayload(
         remote_access_delay = buf.getUInt16();
     }
     if (remote_access_date_flag) {
-        remote_access_date = buf.getMJD(5);
+        remote_access_date = buf.getMJD(MJD_SIZE);
     }
     if (export_controlled_cps) {
         uint8_t cps_vector_count = buf.getUInt8();
@@ -261,8 +261,8 @@ void ts::CPCMDeliverySignallingDescriptor::DisplayDescriptor(TablesDisplay& disp
             disp << margin << "Disable Analogue SD  export: " << UString::TrueFalse(sd_export) << ", consumption: " << UString::TrueFalse(sd_consume) << std::endl;
             disp << margin << "Disable Analogue HD  export: " << UString::TrueFalse(hd_export) << ", consumption: " << UString::TrueFalse(hd_consume) << std::endl;
             if (view_window_activated) {
-                disp << margin << "View window start: " << buf.getMJD(5).format(ts::Time::FieldMask::DATETIME);
-                disp << ", end: " << buf.getMJD(5).format(ts::Time::FieldMask::DATETIME) << std::endl;
+                disp << margin << "View window start: " << buf.getMJD(MJD_SIZE).format(ts::Time::FieldMask::DATETIME);
+                disp << ", end: " << buf.getMJD(MJD_SIZE).format(ts::Time::FieldMask::DATETIME) << std::endl;
             }
             if (view_period_activated) {
                 disp << margin << "View period: " << buf.getUInt16() << " (15 minute periods)" << std::endl;
@@ -274,7 +274,7 @@ void ts::CPCMDeliverySignallingDescriptor::DisplayDescriptor(TablesDisplay& disp
                 disp << margin << "Remote access delay: " << buf.getUInt16() << " (15 minute periods)" << std::endl;
             }
             if (remote_access_date_flag) {
-                disp << margin << "Remote access date: " << buf.getMJD(5).format(ts::Time::FieldMask::DATETIME) << std::endl;
+                disp << margin << "Remote access date: " << buf.getMJD(MJD_SIZE).format(ts::Time::FieldMask::DATETIME) << std::endl;
             }
             if (export_controlled_cps) {
                 uint8_t cps_vector_count = buf.getUInt8();

--- a/src/libtsduck/dtv/descriptors/dvb/tsLocalTimeOffsetDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsLocalTimeOffsetDescriptor.cpp
@@ -99,7 +99,7 @@ void ts::LocalTimeOffsetDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBu
         disp << ", polarity: " << (polarity ? "west" : "east") << " of Greenwich" << std::endl;
         disp << margin << UString::Format(u"Local time offset: %s%02d", polarity ? u"-" : u"", buf.getBCD<uint8_t>(2));
         disp << UString::Format(u":%02d", buf.getBCD<uint8_t>(2)) << std::endl;
-        disp << margin << "Next change: " << buf.getMJD(5).format(Time::DATETIME) << std::endl;
+        disp << margin << "Next change: " << buf.getMJD(MJD_SIZE).format(Time::DATETIME) << std::endl;
         disp << margin << UString::Format(u"Next time offset: %s%02d", polarity ? u"-" : u"", buf.getBCD<uint8_t>(2));
         disp << UString::Format(u":%02d", buf.getBCD<uint8_t>(2)) << std::endl;
     }

--- a/src/libtsduck/dtv/descriptors/isdb/tsSIParameterDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/isdb/tsSIParameterDescriptor.cpp
@@ -14,6 +14,7 @@
 #include "tsDuckContext.h"
 #include "tsxmlElement.h"
 #include "tsNames.h"
+#include "tsMJD.h"
 
 #define MY_XML_NAME u"SI_parameter_descriptor"
 #define MY_CLASS ts::SIParameterDescriptor
@@ -70,7 +71,7 @@ void ts::SIParameterDescriptor::serializePayload(PSIBuffer& buf) const
 void ts::SIParameterDescriptor::deserializePayload(PSIBuffer& buf)
 {
     parameter_version = buf.getUInt8();
-    update_time = buf.getMJD(2); // 2 bytes: date only
+    update_time = buf.getMJD(MJD_MIN_SIZE); // 2 bytes: date only
     while (buf.canRead()) {
         Entry e;
         e.table_id = buf.getUInt8();
@@ -89,7 +90,7 @@ void ts::SIParameterDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer
 {
     if (buf.canReadBytes(3)) {
         disp << margin << UString::Format(u"Parameter version: %n", buf.getUInt8()) << std::endl;
-        disp << margin << "Update time: " << buf.getMJD(2).format(Time::DATE) << std::endl;
+        disp << margin << "Update time: " << buf.getMJD(MJD_MIN_SIZE).format(Time::DATE) << std::endl;
         while (buf.canReadBytes(2)) {
             disp << margin << "- Table id: " << names::TID(disp.duck(), buf.getUInt8(), CASID_NULL, NamesFlags::HEXA_FIRST) << std::endl;
             disp.displayPrivateData(u"Table description", buf, buf.getUInt8(), margin + u"  ");

--- a/src/libtsduck/dtv/descriptors/isdb/tsSIPrimeTSDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/isdb/tsSIPrimeTSDescriptor.cpp
@@ -14,6 +14,7 @@
 #include "tsDuckContext.h"
 #include "tsxmlElement.h"
 #include "tsNames.h"
+#include "tsMJD.h"
 
 #define MY_XML_NAME u"SI_prime_TS_descriptor"
 #define MY_CLASS ts::SIPrimeTSDescriptor
@@ -74,7 +75,7 @@ void ts::SIPrimeTSDescriptor::serializePayload(PSIBuffer& buf) const
 void ts::SIPrimeTSDescriptor::deserializePayload(PSIBuffer& buf)
 {
     parameter_version = buf.getUInt8();
-    update_time = buf.getMJD(2);  // date only
+    update_time = buf.getMJD(MJD_MIN_SIZE);  // date only
     SI_prime_TS_network_id = buf.getUInt16();
     SI_prime_transport_stream_id = buf.getUInt16();
     while (buf.canRead()) {
@@ -95,7 +96,7 @@ void ts::SIPrimeTSDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& 
 {
     if (buf.canReadBytes(7)) {
         disp << margin << UString::Format(u"Parameter version: %n", buf.getUInt8()) << std::endl;
-        disp << margin << "Update time: " << buf.getMJD(2).format(Time::DATE) << std::endl;
+        disp << margin << "Update time: " << buf.getMJD(MJD_MIN_SIZE).format(Time::DATE) << std::endl;
         disp << margin << UString::Format(u"SI prime TS network id: %n", buf.getUInt16()) << std::endl;
         disp << margin << UString::Format(u"SI prime TS id: %n", buf.getUInt16()) << std::endl;
         while (buf.canReadBytes(2)) {

--- a/src/libtsduck/dtv/descriptors/isdb/tsSeriesDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/isdb/tsSeriesDescriptor.cpp
@@ -83,7 +83,7 @@ void ts::SeriesDescriptor::deserializePayload(PSIBuffer& buf)
     buf.getBits(repeat_label, 4);
     buf.getBits(program_pattern, 3);
     if (buf.getBool()) {
-        expire_date = buf.getMJD(2);  // 2 bytes, date only
+        expire_date = buf.getMJD(MJD_MIN_SIZE);  // 2 bytes, date only
     }
     else {
         buf.skipBits(16);
@@ -105,7 +105,7 @@ void ts::SeriesDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf
         disp << margin << UString::Format(u"Repeat label: %d", buf.getBits<uint8_t>(4)) << std::endl;
         disp << margin << "Program pattern: " << DataName(MY_XML_NAME, u"ProgramPattern", buf.getBits<uint8_t>(3), NamesFlags::DECIMAL_FIRST) << std::endl;
         const bool date_valid = buf.getBool();
-        const Time exp(buf.getMJD(2));
+        const Time exp(buf.getMJD(MJD_MIN_SIZE));
         disp << margin << "Expire date: " << (date_valid ? exp.format(Time::DATE) : u"unspecified") << std::endl;
         disp << margin << UString::Format(u"Episode: %d", buf.getBits<uint16_t>(12));
         disp << UString::Format(u"/%d", buf.getBits<uint16_t>(12)) << std::endl;

--- a/src/libtsduck/dtv/signalization/tsPSIBuffer.h
+++ b/src/libtsduck/dtv/signalization/tsPSIBuffer.h
@@ -20,6 +20,7 @@
 #include "tsTime.h"
 #include "tsCharset.h"
 #include "tsTS.h"
+#include "tsMJD.h"
 
 namespace ts {
     //!
@@ -260,7 +261,7 @@ namespace ts {
         //!
         //! @return The deserialize date and time (Epoch on error).
         //!
-        Time getFullMJD() { return getMJD(5); }
+        Time getFullMJD() { return getMJD(MJD_SIZE); }
 
         //!
         //! Get the date part of a Modified Julian Date (MJD), the time part is ignored, 2 bytes.
@@ -269,7 +270,7 @@ namespace ts {
         //!
         //! @return The deserialize date and time (Epoch on error).
         //!
-        Time getDateMJD() { return getMJD(2); }
+        Time getDateMJD() { return getMJD(MJD_MIN_SIZE); }
 
         //!
         //! Get a Modified Julian Date (MJD), 2 to 5 bytes.


### PR DESCRIPTION


<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/download/docs/tsduck-dev.html#chap-contribution

#### Brief description of the proposed changes:
Safer and more readable to use already defined names (more consistent too)

(Something else has broken Windows CI)