### PR TITLE
tsplugin_mux update

### DIFF
--- a/src/tsplugins/tsplugin_mux.cpp
+++ b/src/tsplugins/tsplugin_mux.cpp
@@ -243,7 +243,7 @@ bool ts::MuxPlugin::stop()
 
 ts::ProcessorPlugin::Status ts::MuxPlugin::processPacket(TSPacket& pkt, TSPacketMetadata& pkt_data)
 {
-    // Initialization sequences (executed only once). Executed if there is a target bitrate.
+    // Initialization sequences (executed only once).
     if (_packet_count == 0 && _bitrate != 0) {
         // Compute the inter-packet interval based on the TS bitrate
         BitRate ts_bitrate = tsp->bitrate();
@@ -251,7 +251,8 @@ ts::ProcessorPlugin::Status ts::MuxPlugin::processPacket(TSPacket& pkt, TSPacket
             error(u"input bitrate unknown or too low, specify --inter-packet instead of --bitrate");
             return TSP_END;
         }
-        verbose(u"transport bitrate: %s'd", ts_bitrate);
+        _inter_pkt = (ts_bitrate / _bitrate).toInt();
+        verbose(u"transport bitrate: %s'd b/s, packet interval: %'d", ts_bitrate, _inter_pkt);
     }
 
     // Count TS
@@ -355,14 +356,9 @@ ts::ProcessorPlugin::Status ts::MuxPlugin::processPacket(TSPacket& pkt, TSPacket
         _cc_fixer.feedPacket(pkt);
     }
 
-    // If the target bitrate is specified, compute the next pkt so the bitrate will be closer to the target bitrate.
-    if (_bitrate != 0) {
-        _pid_next_pkt = (_inserted_packet_count * tsp->bitrate() / _bitrate).toInt();
-    }
-    // If not, use the inter_pkt value.
-    else {
-        _pid_next_pkt += _inter_pkt;
-    }
+    // Next insertion point
+    _pid_next_pkt += _inter_pkt;
+
     // Apply labels on muxed packets.
     pkt_data.setLabels(_setLabels);
     pkt_data.clearLabels(_resetLabels);


### PR DESCRIPTION
<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/download/docs/tsduck-dev.html#chap-contribution
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->
The current mux plugin does not generate transport stream with accurate bitrate.
#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->
The only change I made is on `tsplugin_mux.cpp`.
#### Brief description of the proposed changes:
I set the `_pid_next_pkt` to be more accurate by calculate it on the fly. Rather than fixing an `_inter_pkt` that pre determined and truncated to the nearest integer, so It will make the resulted bitrate far from the target bitrate.