### PR TITLE
Fix Windows build script

### DIFF
--- a/scripts/install-wintools/install-ruby.ps1
+++ b/scripts/install-wintools/install-ruby.ps1
@@ -29,7 +29,7 @@ else {
     # Ruby is unconventional here. Instead of a constant package name and different
     # versions, the package name contains the version. Each version has a new package
     # name. Get latest version.
-    $RubyPackage = (winget search --id RubyInstallerTeam.Ruby.3 |
+    $RubyPackage = (winget search --id RubyInstallerTeam.Ruby.3 --accept-source-agreements |
                     Select-String RubyInstallerTeam.Ruby |
                     Select-Object -Last 1) -replace '.* (RubyInstallerTeam\.Ruby\.[\.0-9]*) .*','$1'
     if (-not $RubyPackage) {


### PR DESCRIPTION
#### Affected components:
No TSDuck core code is affected since it is only about the installation files for Windows.

#### Brief description of the proposed changes:
Add --accept-source-agreements flag to remove user interaction which locked the script and could not run farther. See https://learn.microsoft.com/en-us/windows/package-manager/winget/install#license-agreements

However the flag they propose is discontinued and the one I added is the one that works. Manage to try it on another Windows computer that did not agree to the agreements yet using winget.