### PR TITLE
Reorder output to NGA features component descriptor 

### DIFF
--- a/src/libtsduck/dtv/descriptors/dvb/tsComponentDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsComponentDescriptor.cpp
@@ -90,10 +90,10 @@ void ts::ComponentDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& 
         const uint8_t stream_content = buf.getBits<uint8_t>(4);
         const uint8_t component_type = buf.getUInt8();
         disp << margin << "Content/type: " << ComponentTypeName(disp.duck(), stream_content, stream_content_ext, component_type, NamesFlags::FIRST) << std::endl;
-        disp << margin << UString::Format(u"Component tag: %n", buf.getUInt8()) << std::endl;
         if (stream_content_ext == 0xE && stream_content == 0xB) {
             DisplayNGAComponentFeatures(disp, margin + u"  ", component_type);
         }
+        disp << margin << UString::Format(u"Component tag: %n", buf.getUInt8()) << std::endl;
         disp << margin << "Language: " << buf.getLanguageCode() << std::endl;
         if (buf.canRead()) {
             disp << margin << "Description: \"" << buf.getString() << "\"" << std::endl;


### PR DESCRIPTION
The component_type bitwise analysis it not related to the component_tag value