### PR TITLE
Add the --only-pid option to only scramble one component per service

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ VERSION 3.40-4010 (Dec 2024)
   * New options in existing commands and plugins:
     - Option --dvb in all commands and plugins where options --atsc, --isdb and
       similar options on regional standards were defined.
+    - Option --only-pid in the scrambler plugin
 
 [BUG] Bug fixes:
 

--- a/doc/user/plugins/scrambler.adoc
+++ b/doc/user/plugins/scrambler.adoc
@@ -108,6 +108,19 @@ Do not scramble video components in the selected service.
 By default, all video components are scrambled.
 
 [.opt]
+*--only-pid* _pid_
+
+[.optdoc]
+Only scramble the component in the selected service which matches this PID.
+By default, all components are scrambled.
+
+[.optdoc]
+Unlike the -p or --pid options, the provided PID must be part of the selected
+service in order to scramble exactly one of its components.
+Because this option only filters out components and the plugin is still dealing
+with a service, the ECM's and crypto-periods are operational with this option.
+
+[.opt]
 *--partial-scrambling* _count_
 
 [.optdoc]


### PR DESCRIPTION
<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/download/docs/tsduck-dev.html#chap-contribution
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->
#1566 

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->
tsplugin_scrambler

#### Brief description of the proposed changes:

When the `scrambler` plugin is used with a targeted service, this PL allows the user to only apply scrambling on a single elementary stream: `--only-pid`.

This is particularly useful to ensure the elementary streams are scrambled using individual control words.

Since the `scrambler` plugin is still targeting a service, unlike with the use of the `--pid` option, the PMT is used which allows the crypto-period and ECM scheduling to be enabled (see the related issue for details).
