### PR TITLE
Use updated versions of CI dependencies

### DIFF
--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -1,3 +1,4 @@
+---
 #-----------------------------------------------------------------------------
 #
 #  TSDuck - The MPEG Transport Stream Toolkit
@@ -18,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
         compiler: [gcc]
         std: [20]
     name: Sanitizer on ${{ matrix.os }} with ${{ matrix.compiler }}, C++${{ matrix.std }}
@@ -32,34 +33,34 @@ jobs:
       REFERENCE_REPO: tsduck/tsduck
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@master
-    - name: Install dependencies
-      run: |
-        scripts/install-prerequisites.sh
-        ${{ matrix.compiler }} --version
-    - name: Build TSDuck
-      run: make -j5
-    - name: Check built version
-      run: make show-version
-    - name: Run unitary tests
-      run: make test
-    - name: Download test suite
-      run: |
-        # Try to download '<repo>-test' from the pull request owner, if there is one.
-        if curl -fsL "https://github.com/${ORIGIN_REPO}-test/tarball/master" -o test.tgz; then
-            echo "Downloaded test suite from $ORIGIN_REPO"
-        else
-            curl -fsL "https://github.com/${REFERENCE_REPO}-test/tarball/master" -o test.tgz
-            echo "Downloaded test suite from $REFERENCE_REPO"
-        fi
-        mkdir -p ../tsduck-test
-        tar -C ../tsduck-test -x -z -f test.tgz --strip 1
-    - name: Run test suite
-      run: |
-        make test-suite && status=$? || status=$?
-        cd ../tsduck-test
-        for f in $(find tmp -name '*.diff'); do
-            echo "==== $f";
-            cat "$f"
-        done
-        exit $status
+      - uses: actions/checkout@master
+      - name: Install dependencies
+        run: |
+          scripts/install-prerequisites.sh
+          ${{ matrix.compiler }} --version
+      - name: Build TSDuck
+        run: make -j5
+      - name: Check built version
+        run: make show-version
+      - name: Run unitary tests
+        run: make test
+      - name: Download test suite
+        run: |
+          # Try to download '<repo>-test' from the pull request owner, if there is one.
+          if curl -fsL "https://github.com/${ORIGIN_REPO}-test/tarball/master" -o test.tgz; then
+              echo "Downloaded test suite from $ORIGIN_REPO"
+          else
+              curl -fsL "https://github.com/${REFERENCE_REPO}-test/tarball/master" -o test.tgz
+              echo "Downloaded test suite from $REFERENCE_REPO"
+          fi
+          mkdir -p ../tsduck-test
+          tar -C ../tsduck-test -x -z -f test.tgz --strip 1
+      - name: Run test suite
+        run: |
+          make test-suite && status=$? || status=$?
+          cd ../tsduck-test
+          for f in $(find tmp -name '*.diff'); do
+              echo "==== $f";
+              cat "$f"
+          done
+          exit $status

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,3 +1,4 @@
+---
 #-----------------------------------------------------------------------------
 #
 #  TSDuck - The MPEG Transport Stream Toolkit
@@ -23,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
         compiler: [gcc]
         std: [20]
     name: Coverage on ${{ matrix.os }} with ${{ matrix.compiler }}, C++${{ matrix.std }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,3 +1,4 @@
+---
 #-----------------------------------------------------------------------------
 #
 #  TSDuck - The MPEG Transport Stream Toolkit
@@ -21,7 +22,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       actions: read
@@ -37,38 +38,38 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Install dependencies
-      run: scripts/install-prerequisites.sh
+      - name: Install dependencies
+        run: scripts/install-prerequisites.sh
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        config: |
-          paths:
-          - src
-          paths-ignore:
-          - src/utest
-          query-filters:
-          - exclude:
-            # CWE-327: Use of a broken or risky cryptographic algorithm
-            # We use DES for SCTE52, this is history, not a security alert
-            tags: /cwe-327/
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config: |
+            paths:
+            - src
+            paths-ignore:
+            - src/utest
+            query-filters:
+            - exclude:
+              # CWE-327: Use of a broken or risky cryptographic algorithm
+              # We use DES for SCTE52, this is history, not a security alert
+              tags: /cwe-327/
 
-    - if: matrix.language == 'cpp'
-      name: Custom build (C++)
-      run: make -j5 NOTEST=1
+      - if: matrix.language == 'cpp'
+        name: Custom build (C++)
+        run: make -j5 NOTEST=1
 
-    - if: matrix.language == 'java'
-      name: Custom build (Java)
-      run: make -C src/libtsduck/java
+      - if: matrix.language == 'java'
+        name: Custom build (Java)
+        run: make -C src/libtsduck/java
 
-    - if: matrix.language == 'python'
-      name: Autobuild (Python)
-      uses: github/codeql-action/autobuild@v3
+      - if: matrix.language == 'python'
+        name: Autobuild (Python)
+        uses: github/codeql-action/autobuild@v3
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/flawfinder-analysis.yml
+++ b/.github/workflows/flawfinder-analysis.yml
@@ -1,3 +1,4 @@
+---
 #-----------------------------------------------------------------------------
 #
 #  TSDuck - The MPEG Transport Stream Toolkit
@@ -27,7 +28,7 @@ on:
 jobs:
   flawfinder:
     name: Flawfinder
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -37,12 +38,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: flawfinder_scan
-        uses: david-a-wheeler/flawfinder@8e4a779ad59dbfaee5da586aa9210853b701959c
+        uses: david-a-wheeler/flawfinder@2.0.19
         with:
-          arguments: '--sarif ./'
-          output: 'flawfinder_results.sarif'
+          arguments: "--sarif ./"
+          output: "flawfinder_results.sarif"
 
       - name: Upload analysis results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{github.workspace}}/flawfinder_results.sarif

--- a/.github/workflows/flawfinder-analysis.yml
+++ b/.github/workflows/flawfinder-analysis.yml
@@ -44,6 +44,6 @@ jobs:
           output: "flawfinder_results.sarif"
 
       - name: Upload analysis results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{github.workspace}}/flawfinder_results.sarif


### PR DESCRIPTION
Use Ubuntu 24.04 as for CI runner execution while update is "rolling out"
Update relevant CodeQL actions.

Still an issue in the "Coverage" ci related to building ` tsduck.tables.model.xml`
