### PR TITLE
DSM-CC Object Carousel: Part 1 - Initial PR: Tables/Descriptors Support (issue #82)

### DIFF
--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.adoc
@@ -1,0 +1,9 @@
+==== dsmcc_CRC32_descriptor
+
+Defined by DVB in <<ETSI-301-192>>.
+
+[source,xml]
+----
+<dsmcc_CRC32_descriptor
+    CRC_32="uint32, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.cpp
@@ -17,18 +17,17 @@
 
 #define MY_XML_NAME u"dsmcc_CRC32_descriptor"
 #define MY_CLASS    ts::DSMCCCRC32Descriptor
-#define MY_DID      ts::DID_DSMCC_CRC32
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_CRC32, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
 
 //----------------------------------------------------------------------------
 // Constructors.
 //----------------------------------------------------------------------------
 
 ts::DSMCCCRC32Descriptor::DSMCCCRC32Descriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
@@ -48,7 +47,7 @@ void ts::DSMCCCRC32Descriptor::clearContent()
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCCRC32Descriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCCRC32Descriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     if (buf.canReadBytes(4)) {
         const uint32_t crc32 = buf.getUInt32();

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.cpp
@@ -52,7 +52,7 @@ void ts::DSMCCCRC32Descriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer&
 {
     if (buf.canReadBytes(4)) {
         const uint32_t crc32 = buf.getUInt32();
-        disp << margin << "CRC32: " << crc32 << std::endl;
+        disp << margin << UString::Format(u"CRC32: %n", crc32) << std::endl;
     }
 }
 

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.cpp
@@ -1,0 +1,97 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCCRC32Descriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+#include "tsNames.h"
+
+#define MY_XML_NAME u"dsmcc_CRC32_descriptor"
+#define MY_CLASS    ts::DSMCCCRC32Descriptor
+#define MY_DID      ts::DID_DSMCC_CRC32
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+//----------------------------------------------------------------------------
+// Constructors.
+//----------------------------------------------------------------------------
+
+ts::DSMCCCRC32Descriptor::DSMCCCRC32Descriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCCRC32Descriptor::DSMCCCRC32Descriptor(DuckContext& duck, const Descriptor& desc) :
+    DSMCCCRC32Descriptor()
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCCRC32Descriptor::clearContent()
+{
+    crc32 = 0;
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCRC32Descriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(4)) {
+        const uint32_t crc32 = buf.getUInt32();
+        disp << margin << "CRC32: " << crc32 << std::endl;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCRC32Descriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putUInt32(crc32);
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCRC32Descriptor::deserializePayload(PSIBuffer& buf)
+{
+    crc32 = buf.getUInt32();
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCRC32Descriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"CRC_32", crc32, true);
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCCRC32Descriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getIntAttribute(crc32, u"CRC_32", true);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.h
@@ -1,0 +1,53 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a CRC32_descriptor (DSM-CC U-N Message DSI/DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of a CRC32_descriptor (DSM-CC U-N Message DII specific).
+    //! This descriptor cannot be present in other tables than a DII (0x3B)
+    //!
+    //! @see ETSI EN 301 192 V1.7.1 (2021-08), 10.2.6
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCCRC32Descriptor: public AbstractDescriptor {
+    public:
+        // DSMCCCRC32Descriptor public members:
+        uint32_t crc32 = 0;  //!< CRC32 value
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCCRC32Descriptor();
+
+        //!
+        //! Constructor from a binary descriptor.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCCRC32Descriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCRC32Descriptor.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_CRC32_descriptor
+      CRC_32="uint32, required">
+    </dsmcc_CRC32_descriptor>
+
+  </_descriptors>
+</tsduck>
+

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.adoc
@@ -1,0 +1,10 @@
+==== dsmcc_caching_proiority_descriptor
+
+Defined by DVB in <<ETSI-102-727>>.
+
+[source,xml]
+----
+<dsmcc_caching_priority_descriptor
+    priority_value="uint8, required"
+    transparency_level="uint8, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.cpp
@@ -54,7 +54,7 @@ void ts::DSMCCCachingPriorityDescriptor::DisplayDescriptor(TablesDisplay& disp, 
     if (buf.canReadBytes(2)) {
         const uint8_t priority_value = buf.getUInt8();
         const uint8_t transparency_level = buf.getUInt8();
-        disp << margin << "Priority Value: " << priority_value << std::endl;
+        disp << margin << UString::Format(u"Priority Value: %n", priority_value) << std::endl;
         disp << margin << "Transparency Level: " << DataName(MY_XML_NAME, u"transparency_level", transparency_level, NamesFlags::HEXA_FIRST) << std::endl;
     }
 }

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.cpp
@@ -17,18 +17,17 @@
 
 #define MY_XML_NAME u"dsmcc_caching_priority_descriptor"
 #define MY_CLASS    ts::DSMCCCachingPriorityDescriptor
-#define MY_DID      ts::DID_DSMCC_CACHING_PRIORITY
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_CACHING_PRIORITY, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
 
 //----------------------------------------------------------------------------
 // Constructors.
 //----------------------------------------------------------------------------
 
 ts::DSMCCCachingPriorityDescriptor::DSMCCCachingPriorityDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
@@ -49,7 +48,7 @@ void ts::DSMCCCachingPriorityDescriptor::clearContent()
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCCachingPriorityDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCCachingPriorityDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     if (buf.canReadBytes(2)) {
         const uint8_t priority_value = buf.getUInt8();

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.cpp
@@ -1,0 +1,104 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCCachingPriorityDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+#include "tsNames.h"
+
+#define MY_XML_NAME u"dsmcc_caching_priority_descriptor"
+#define MY_CLASS    ts::DSMCCCachingPriorityDescriptor
+#define MY_DID      ts::DID_DSMCC_CACHING_PRIORITY
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+//----------------------------------------------------------------------------
+// Constructors.
+//----------------------------------------------------------------------------
+
+ts::DSMCCCachingPriorityDescriptor::DSMCCCachingPriorityDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCCachingPriorityDescriptor::DSMCCCachingPriorityDescriptor(DuckContext& duck, const Descriptor& desc) :
+    DSMCCCachingPriorityDescriptor()
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCCachingPriorityDescriptor::clearContent()
+{
+    priority_value = 0;
+    transparency_level = 0;
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCachingPriorityDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(2)) {
+        const uint8_t priority_value = buf.getUInt8();
+        const uint8_t transparency_level = buf.getUInt8();
+        disp << margin << "Priority Value: " << priority_value << std::endl;
+        disp << margin << "Transparency Level: " << DataName(MY_XML_NAME, u"transparency_level", transparency_level, NamesFlags::HEXA_FIRST) << std::endl;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCachingPriorityDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putUInt8(priority_value);
+    buf.putUInt8(transparency_level);
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCachingPriorityDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    priority_value = buf.getUInt8();
+    transparency_level = buf.getUInt8();
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCachingPriorityDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"priority_value", priority_value, true);
+    root->setIntAttribute(u"transparency_level", transparency_level, true);
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCCachingPriorityDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getIntAttribute(priority_value, u"priority_value", true) &&
+           element->getIntAttribute(transparency_level, u"transparency_level", true);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.h
@@ -1,0 +1,54 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a caching_priority_descriptor (DSM-CC U-N Message DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of a caching_priority_descriptor (DSM-CC U-N Message DII specific).
+    //! This descriptor cannot be present in other tables than a DII (0x3B)
+    //!
+    //! @see ETSI TS 102 809 V1.3.1 (2017-06), B.2.2.4.2
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCCachingPriorityDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCCachingPriorityDescriptor public members:
+        uint8_t priority_value = 0;      //!< Indicates the caching priority for the objects within this module.
+        uint8_t transparency_level = 0;  //!< Transparency level that shall be used by the receiver if it caches objects contained in this module.
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCCachingPriorityDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCCachingPriorityDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.names
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.names
@@ -1,0 +1,7 @@
+[dsmcc_caching_priority_descriptor.transparency_level]
+Bits = 8
+0 = Reserved
+1 = Transparent caching
+2 = Semi-transparent caching
+3 = Static caching
+4-255 = Reserved for future use

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCachingPriorityDescriptor.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_caching_priority_descriptor
+      priority_value="uint8, required"
+      transparency_level="uint8, required">
+    </dsmcc_caching_priority_descriptor>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.adoc
@@ -1,0 +1,10 @@
+==== dsmcc_compressed_module_descriptor
+
+Defined by DVB in <<ETSI-301-192>>.
+
+[source,xml]
+----
+<dsmcc_compressed_module_descriptor
+    compression_method="uint8, required"
+    original_size="uint32, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.cpp
@@ -17,18 +17,17 @@
 
 #define MY_XML_NAME u"dsmcc_compressed_module_descriptor"
 #define MY_CLASS    ts::DSMCCCompressedModuleDescriptor
-#define MY_DID      ts::DID_DSMCC_COMPRESSED_MODULE
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_COMPRESSED_MODULE, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
 
 //----------------------------------------------------------------------------
 // Constructors.
 //----------------------------------------------------------------------------
 
 ts::DSMCCCompressedModuleDescriptor::DSMCCCompressedModuleDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
@@ -49,7 +48,7 @@ void ts::DSMCCCompressedModuleDescriptor::clearContent()
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCCompressedModuleDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCCompressedModuleDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     if (buf.canReadBytes(5)) {
         const uint8_t  compression_method = buf.getUInt8();

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.cpp
@@ -53,9 +53,9 @@ void ts::DSMCCCompressedModuleDescriptor::DisplayDescriptor(TablesDisplay& disp,
 {
     if (buf.canReadBytes(5)) {
         const uint8_t  compression_method = buf.getUInt8();
-        const uint32_t original_size = buf.getUInt16();
-        disp << margin << "Compression Method: " << compression_method << std::endl;
-        disp << margin << "Original Size: " << original_size << std::endl;
+        const uint32_t original_size = buf.getUInt32();
+        disp << margin << UString::Format(u"Compression Method: %n", compression_method) << std::endl;
+        disp << margin << UString::Format(u"Original Size: %n", original_size) << std::endl;
     }
 }
 

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.cpp
@@ -1,0 +1,104 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCCompressedModuleDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+#include "tsNames.h"
+
+#define MY_XML_NAME u"dsmcc_compressed_module_descriptor"
+#define MY_CLASS    ts::DSMCCCompressedModuleDescriptor
+#define MY_DID      ts::DID_DSMCC_COMPRESSED_MODULE
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+//----------------------------------------------------------------------------
+// Constructors.
+//----------------------------------------------------------------------------
+
+ts::DSMCCCompressedModuleDescriptor::DSMCCCompressedModuleDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCCompressedModuleDescriptor::DSMCCCompressedModuleDescriptor(DuckContext& duck, const Descriptor& desc) :
+    DSMCCCompressedModuleDescriptor()
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCCompressedModuleDescriptor::clearContent()
+{
+    compression_method = 0;
+    original_size = 0;
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCompressedModuleDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(5)) {
+        const uint8_t  compression_method = buf.getUInt8();
+        const uint32_t original_size = buf.getUInt16();
+        disp << margin << "Compression Method: " << compression_method << std::endl;
+        disp << margin << "Original Size: " << original_size << std::endl;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCompressedModuleDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putUInt8(compression_method);
+    buf.putUInt32(original_size);
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCompressedModuleDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    compression_method = buf.getUInt8();
+    original_size = buf.getUInt32();
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCCompressedModuleDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"compression_method", compression_method, true);
+    root->setIntAttribute(u"original_size", original_size, true);
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCCompressedModuleDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getIntAttribute(compression_method, u"compression_method", true) &&
+           element->getIntAttribute(original_size, u"original_size", true);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.h
@@ -1,0 +1,54 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a group_link_descriptor (DSM-CC U-N Message DSI/DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of a compressed_module_descriptor (DSM-CC U-N Message DII specific).
+    //! This descriptor cannot be present in other tables than a DII (0x3B)
+    //!
+    //! @see ETSI EN 301 192 V1.7.1 (2021-08), 10.2.11
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCCompressedModuleDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCCompressedModuleDescriptor public members:
+        uint8_t  compression_method = 0;  //!< Compression method identifier.
+        uint32_t original_size = 0;       //!< Size in bylte of the module prior to compression.
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCCompressedModuleDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCCompressedModuleDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCCompressedModuleDescriptor.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_compressed_module_descriptor
+      compression_method="uint8, required"
+      original_size="uint32, required">
+    </dsmcc_compressed_module_descriptor>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.adoc
@@ -1,0 +1,9 @@
+==== dsmcc_est_download_time_descriptor
+
+Defined by DVB in <<ETSI-301-192>>.
+
+[source,xml]
+----
+<dsmcc_est_download_time_descriptor
+    est_download_time="uint32, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.cpp
@@ -17,18 +17,17 @@
 
 #define MY_XML_NAME u"dsmcc_est_download_time_descriptor"
 #define MY_CLASS    ts::DSMCCEstDownloadTimeDescriptor
-#define MY_DID      ts::DID_DSMCC_EST_DOWNLOAD_TIME
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_EST_DOWNLOAD_TIME, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
 
 //----------------------------------------------------------------------------
 // Constructors.
 //----------------------------------------------------------------------------
 
 ts::DSMCCEstDownloadTimeDescriptor::DSMCCEstDownloadTimeDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
@@ -48,7 +47,7 @@ void ts::DSMCCEstDownloadTimeDescriptor::clearContent()
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCEstDownloadTimeDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCEstDownloadTimeDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     if (buf.canReadBytes(4)) {
         disp << margin << UString::Format(u"Estimated Download Time: %n", buf.getUInt32()) << std::endl;

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.cpp
@@ -1,0 +1,96 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCEstDownloadTimeDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+#include "tsNames.h"
+
+#define MY_XML_NAME u"dsmcc_est_download_time_descriptor"
+#define MY_CLASS    ts::DSMCCEstDownloadTimeDescriptor
+#define MY_DID      ts::DID_DSMCC_EST_DOWNLOAD_TIME
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+//----------------------------------------------------------------------------
+// Constructors.
+//----------------------------------------------------------------------------
+
+ts::DSMCCEstDownloadTimeDescriptor::DSMCCEstDownloadTimeDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCEstDownloadTimeDescriptor::DSMCCEstDownloadTimeDescriptor(DuckContext& duck, const Descriptor& desc) :
+    DSMCCEstDownloadTimeDescriptor()
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCEstDownloadTimeDescriptor::clearContent()
+{
+    est_download_time = 0;
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCEstDownloadTimeDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(4)) {
+        disp << margin << "Estimated Download Time: " << buf.getUInt32() << std::endl;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCEstDownloadTimeDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putUInt32(est_download_time);
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCEstDownloadTimeDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    est_download_time = buf.getUInt32();
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCEstDownloadTimeDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"est_download_time", est_download_time, true);
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCEstDownloadTimeDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getIntAttribute(est_download_time, u"est_download_time", true);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.cpp
@@ -51,7 +51,7 @@ void ts::DSMCCEstDownloadTimeDescriptor::clearContent()
 void ts::DSMCCEstDownloadTimeDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
 {
     if (buf.canReadBytes(4)) {
-        disp << margin << "Estimated Download Time: " << buf.getUInt32() << std::endl;
+        disp << margin << UString::Format(u"Estimated Download Time: %n", buf.getUInt32()) << std::endl;
     }
 }
 

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.h
@@ -1,0 +1,53 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a est_download_time_descriptor (DSM-CC U-N Message DSI/DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of a est_download_time_descriptor (DSM-CC U-N Message DSI specific).
+    //! This descriptor cannot be present in other tables than a DSI (0x3B)
+    //!
+    //! @see ETSI EN 301 192 V1.7.1 (2021-08), 10.2.8
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCEstDownloadTimeDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCEstDownloadTimeDescriptor public members:
+        uint32_t est_download_time = 0;  //!< Estimated download time of data in seconds.
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCEstDownloadTimeDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCEstDownloadTimeDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCEstDownloadTimeDescriptor.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_est_download_time_descriptor
+      est_download_time="uint32, required">
+    </dsmcc_est_download_time_descriptor>
+
+  </_descriptors>
+</tsduck>
+

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.adoc
@@ -1,0 +1,10 @@
+==== dsmcc_group_link_descriptor
+
+Defined by DVB in <<ETSI-301-192>>.
+
+[source,xml]
+----
+<dsmcc_group_link_descriptor
+    position="uint8, required"
+    group_id="uint32, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.cpp
@@ -55,7 +55,7 @@ void ts::DSMCCGroupLinkDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuf
         const uint8_t  position = buf.getUInt8();
         const uint32_t group_id = buf.getUInt32();
         disp << margin << "Position: " << DataName(MY_XML_NAME, u"position", position, NamesFlags::HEXA_FIRST) << std::endl;
-        disp << margin << "Group Id: " << group_id << std::endl;
+        disp << margin << UString::Format(u"Group Id: %n", group_id) << std::endl;
     }
 }
 

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.cpp
@@ -17,18 +17,17 @@
 
 #define MY_XML_NAME u"dsmcc_module_link_descriptor"
 #define MY_CLASS    ts::DSMCCGroupLinkDescriptor
-#define MY_DID      ts::DID_DSMCC_GROUP_LINK
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_GROUP_LINK, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
 
 //----------------------------------------------------------------------------
 // Constructors.
 //----------------------------------------------------------------------------
 
 ts::DSMCCGroupLinkDescriptor::DSMCCGroupLinkDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
@@ -49,7 +48,7 @@ void ts::DSMCCGroupLinkDescriptor::clearContent()
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCGroupLinkDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCGroupLinkDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     if (buf.canReadBytes(5)) {
         const uint8_t  position = buf.getUInt8();

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.cpp
@@ -1,0 +1,104 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCGroupLinkDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+#include "tsNames.h"
+
+#define MY_XML_NAME u"dsmcc_module_link_descriptor"
+#define MY_CLASS    ts::DSMCCGroupLinkDescriptor
+#define MY_DID      ts::DID_DSMCC_GROUP_LINK
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+//----------------------------------------------------------------------------
+// Constructors.
+//----------------------------------------------------------------------------
+
+ts::DSMCCGroupLinkDescriptor::DSMCCGroupLinkDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCGroupLinkDescriptor::DSMCCGroupLinkDescriptor(DuckContext& duck, const Descriptor& desc) :
+    DSMCCGroupLinkDescriptor()
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCGroupLinkDescriptor::clearContent()
+{
+    position = 0;
+    group_id = 0;
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCGroupLinkDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(5)) {
+        const uint8_t  position = buf.getUInt8();
+        const uint32_t group_id = buf.getUInt32();
+        disp << margin << "Position: " << DataName(MY_XML_NAME, u"position", position, NamesFlags::HEXA_FIRST) << std::endl;
+        disp << margin << "Group Id: " << group_id << std::endl;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCGroupLinkDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putUInt8(position);
+    buf.putUInt32(group_id);
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCGroupLinkDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    position = buf.getUInt8();
+    group_id = buf.getUInt32();
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCGroupLinkDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"position", position, true);
+    root->setIntAttribute(u"group_id", group_id, true);
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCGroupLinkDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getIntAttribute(position, u"position", true) &&
+           element->getIntAttribute(group_id, u"group_id", true);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.h
@@ -1,0 +1,54 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a group_link_descriptor (DSM-CC U-N Message DSI/DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of a group_link_descriptor (DSM-CC U-N Message DSI specific).
+    //! This descriptor cannot be present in other tables than a DSI (0x3B)
+    //!
+    //! @see ETSI EN 301 192 V1.7.1 (2021-08), 10.2.9
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCGroupLinkDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCGroupLinkDescriptor public members:
+        uint8_t  position = 0;  //!< Position of the group.
+        uint32_t group_id = 0;  //!< Group Id
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCGroupLinkDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCGroupLinkDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.names
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.names
@@ -1,0 +1,5 @@
+[dsmcc_group_link_descriptor.position]
+Bits = 8
+0x00 = First group description of the list
+0x01 = Intermediate group description in the list
+0x02 = Last group description of the list

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCGroupLinkDescriptor.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_group_link_descriptor
+      position="uint8, required"
+      group_id="uint32, required">
+    </dsmcc_group_link_descriptor>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.adoc
@@ -1,0 +1,10 @@
+==== dsmcc_info_descriptor
+
+Defined by DVB in <<ETSI-301-192>>.
+
+[source,xml]
+----
+<dsmcc_info_descriptor
+    language_code="char3, required"
+    info="string, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.cpp
@@ -69,8 +69,8 @@ void ts::DSMCCInfoDescriptor::deserializePayload(PSIBuffer& buf)
 void ts::DSMCCInfoDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
 {
     if (buf.canReadBytes(3)) {
-        disp << margin << "Language: " << buf.getLanguageCode() << std::endl;
-        disp << margin << "Module or Group info: " << buf.getString() << std::endl;
+        disp << margin << "Language: \"" << buf.getLanguageCode() << "\"" << std::endl;
+        disp << margin << "Module or Group info: \"" << buf.getString() << "\"" << std::endl;
     }
 }
 

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.cpp
@@ -16,11 +16,9 @@
 
 #define MY_XML_NAME u"dsmcc_info_descriptor"
 #define MY_CLASS    ts::DSMCCInfoDescriptor
-#define MY_DID      ts::DID_DSMCC_INFO
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_INFO, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
 
 
 //----------------------------------------------------------------------------
@@ -28,7 +26,7 @@ TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML
 //----------------------------------------------------------------------------
 
 ts::DSMCCInfoDescriptor::DSMCCInfoDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
@@ -66,7 +64,7 @@ void ts::DSMCCInfoDescriptor::deserializePayload(PSIBuffer& buf)
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCInfoDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCInfoDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     if (buf.canReadBytes(3)) {
         disp << margin << "Language: \"" << buf.getLanguageCode() << "\"" << std::endl;

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.cpp
@@ -1,0 +1,92 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCInfoDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+
+#define MY_XML_NAME u"dsmcc_info_descriptor"
+#define MY_CLASS    ts::DSMCCInfoDescriptor
+#define MY_DID      ts::DID_DSMCC_INFO
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+
+//----------------------------------------------------------------------------
+// Constructors
+//----------------------------------------------------------------------------
+
+ts::DSMCCInfoDescriptor::DSMCCInfoDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCInfoDescriptor::DSMCCInfoDescriptor(DuckContext& duck, const Descriptor& desc) :
+    DSMCCInfoDescriptor()
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCInfoDescriptor::clearContent()
+{
+    language_code.clear();
+    info.clear();
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCInfoDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putLanguageCode(language_code);
+    buf.putString(info);
+}
+
+void ts::DSMCCInfoDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    buf.getLanguageCode(language_code);
+    buf.getString(info);
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCInfoDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(3)) {
+        disp << margin << "Language: " << buf.getLanguageCode() << std::endl;
+        disp << margin << "Module or Group info: " << buf.getString() << std::endl;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCInfoDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setAttribute(u"language_code", language_code);
+    root->setAttribute(u"info", info);
+}
+
+bool ts::DSMCCInfoDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getAttribute(language_code, u"language_code", true, UString(), 3, 3) &&
+           element->getAttribute(info, u"info", true, UString(), 0, MAX_DESCRIPTOR_SIZE - 5);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.h
@@ -1,0 +1,52 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a info_descriptor (DSM-CC U-N Message DSI/DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of a info_descriptor (DSM-CC U-N Message DSI/DII specific).
+    //! @see ETSI EN 301 192 V1.7.1 (2021-08), 10.2.4
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCInfoDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCInfoDescriptor public members:
+        UString language_code {};  //!< ISO-639 language code, 3 chars.
+        UString info {};           //!< Module or Group info.
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCInfoDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCInfoDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCInfoDescriptor.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_info_descriptor
+      language_code="char3, required"
+      info="string, required">
+    </dsmcc_info_descriptor>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.adoc
@@ -1,0 +1,8 @@
+==== dsmcc_label_descriptor
+
+Defined by DVB in <<ETSI-102-727>>.
+
+[source,xml]
+----
+<dsmcc_label_descriptor label="string, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.cpp
@@ -1,0 +1,84 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCLabelDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIBuffer.h"
+#include "tsPSIRepository.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+
+#define MY_XML_NAME u"dsmcc_label_descriptor"
+#define MY_CLASS    ts::DSMCCLabelDescriptor
+#define MY_DID      ts::DID_DSMCC_LABEL
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+
+//----------------------------------------------------------------------------
+// Constructors
+//----------------------------------------------------------------------------
+
+ts::DSMCCLabelDescriptor::DSMCCLabelDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCLabelDescriptor::DSMCCLabelDescriptor(DuckContext& duck, const Descriptor& desc) :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCLabelDescriptor::clearContent()
+{
+    label.clear();
+}
+
+
+//----------------------------------------------------------------------------
+// Binary serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCLabelDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putString(label);
+}
+
+void ts::DSMCCLabelDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    buf.getString(label);
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCLabelDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    disp << margin << "Module label: \"" << buf.getString() << "\"" << std::endl;
+}
+
+
+//----------------------------------------------------------------------------
+// XML
+//----------------------------------------------------------------------------
+
+void ts::DSMCCLabelDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setAttribute(u"label", label);
+}
+
+bool ts::DSMCCLabelDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getAttribute(label, u"label", true, u"", 0, MAX_DESCRIPTOR_SIZE - 2);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.cpp
@@ -16,11 +16,9 @@
 
 #define MY_XML_NAME u"dsmcc_label_descriptor"
 #define MY_CLASS    ts::DSMCCLabelDescriptor
-#define MY_DID      ts::DID_DSMCC_LABEL
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_LABEL, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
 
 
 //----------------------------------------------------------------------------
@@ -28,12 +26,12 @@ TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML
 //----------------------------------------------------------------------------
 
 ts::DSMCCLabelDescriptor::DSMCCLabelDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
 ts::DSMCCLabelDescriptor::DSMCCLabelDescriptor(DuckContext& duck, const Descriptor& desc) :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
     deserialize(duck, desc);
 }
@@ -63,7 +61,7 @@ void ts::DSMCCLabelDescriptor::deserializePayload(PSIBuffer& buf)
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCLabelDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCLabelDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     disp << margin << "Module label: \"" << buf.getString() << "\"" << std::endl;
 }

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.h
@@ -1,0 +1,52 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a label_descriptor (DSM-CC U-N Message DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+#include "tsUString.h"
+
+namespace ts {
+    //!
+    //! Representation of a label_descriptor.
+    //! @see ETSI TS 102 727 V1.1.1 (2010-01), B.2.2.4.1
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCLabelDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCLabelDescriptor public members:
+        UString label {};  //!< Label of the module.
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCLabelDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCLabelDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer& buf) const override;
+        virtual void deserializePayload(PSIBuffer& buf) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLabelDescriptor.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_label_descriptor label="string, required"/>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.adoc
@@ -1,0 +1,9 @@
+==== dsmcc_location_descriptor
+
+Defined by DVB in <<ETSI-301-192>>.
+
+[source,xml]
+----
+<dsmcc_location_descriptor
+    location_tag="uint8, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.cpp
@@ -1,0 +1,97 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCLocationDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+#include "tsNames.h"
+
+#define MY_XML_NAME u"dsmcc_location_descriptor"
+#define MY_CLASS    ts::DSMCCLocationDescriptor
+#define MY_DID      ts::DID_DSMCC_LOCATION
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+
+//----------------------------------------------------------------------------
+// Constructors.
+//----------------------------------------------------------------------------
+
+ts::DSMCCLocationDescriptor::DSMCCLocationDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCLocationDescriptor::DSMCCLocationDescriptor(DuckContext& duck, const Descriptor& desc) :
+    DSMCCLocationDescriptor()
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCLocationDescriptor::clearContent()
+{
+    location_tag = 0;
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCLocationDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(1)) {
+        disp << margin << "Location Tag: " << buf.getUInt8() << std::endl;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCLocationDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putUInt8(location_tag);
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCLocationDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    location_tag = buf.getUInt8();
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCLocationDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"location_tag", location_tag, true);
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCLocationDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getIntAttribute(location_tag, u"location_tag", true);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.cpp
@@ -52,7 +52,7 @@ void ts::DSMCCLocationDescriptor::clearContent()
 void ts::DSMCCLocationDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
 {
     if (buf.canReadBytes(1)) {
-        disp << margin << "Location Tag: " << buf.getUInt8() << std::endl;
+        disp << margin << UString::Format(u"Location Tag: %n", buf.getUInt8()) << std::endl;
     }
 }
 

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.cpp
@@ -17,11 +17,9 @@
 
 #define MY_XML_NAME u"dsmcc_location_descriptor"
 #define MY_CLASS    ts::DSMCCLocationDescriptor
-#define MY_DID      ts::DID_DSMCC_LOCATION
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_LOCATION, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
 
 
 //----------------------------------------------------------------------------
@@ -29,7 +27,7 @@ TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML
 //----------------------------------------------------------------------------
 
 ts::DSMCCLocationDescriptor::DSMCCLocationDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
@@ -49,7 +47,7 @@ void ts::DSMCCLocationDescriptor::clearContent()
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCLocationDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCLocationDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     if (buf.canReadBytes(1)) {
         disp << margin << UString::Format(u"Location Tag: %n", buf.getUInt8()) << std::endl;

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.h
@@ -1,0 +1,53 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a location_descriptor (DSM-CC U-N Message DSI/DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of a location_descriptor (DSM-CC U-N Message DSI/DII specific).
+    //! This descriptor cannot be present in other tables than a DSI or DII (0x3B)
+    //!
+    //! @see ETSI EN 301 192 V1.7.1 (2021-08), 10.2.7
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCLocationDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCLocationDescriptor public members:
+        uint8_t location_tag = 0;  //!< Value as the component_tag in the stream identifier descriptor.
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCLocationDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCLocationDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCLocationDescriptor.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_location_descriptor
+      location_tag="uint8, required">
+    </dsmcc_location_descriptor>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.adoc
@@ -1,0 +1,10 @@
+==== dsmcc_module_link_descriptor
+
+Defined by DVB in <<ETSI-301-192>>.
+
+[source,xml]
+----
+<dsmcc_module_link_descriptor
+    position="uint8, required"
+    module_id="uint16, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.cpp
@@ -55,7 +55,7 @@ void ts::DSMCCModuleLinkDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBu
         const uint8_t  position = buf.getUInt8();
         const uint16_t module_id = buf.getUInt16();
         disp << margin << "Position: " << DataName(MY_XML_NAME, u"position", position, NamesFlags::HEXA_FIRST) << std::endl;
-        disp << margin << "Module Id: " << module_id << std::endl;
+        disp << margin << UString::Format(u"Module Id: %n", module_id) << std::endl;
     }
 }
 

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.cpp
@@ -1,0 +1,104 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCModuleLinkDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+#include "tsNames.h"
+
+#define MY_XML_NAME u"dsmcc_module_link_descriptor"
+#define MY_CLASS    ts::DSMCCModuleLinkDescriptor
+#define MY_DID      ts::DID_DSMCC_MODULE_LINK
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+//----------------------------------------------------------------------------
+// Constructors.
+//----------------------------------------------------------------------------
+
+ts::DSMCCModuleLinkDescriptor::DSMCCModuleLinkDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCModuleLinkDescriptor::DSMCCModuleLinkDescriptor(DuckContext& duck, const Descriptor& desc) :
+    DSMCCModuleLinkDescriptor()
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCModuleLinkDescriptor::clearContent()
+{
+    position = 0;
+    module_id = 0;
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCModuleLinkDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(3)) {
+        const uint8_t  position = buf.getUInt8();
+        const uint16_t module_id = buf.getUInt16();
+        disp << margin << "Position: " << DataName(MY_XML_NAME, u"position", position, NamesFlags::HEXA_FIRST) << std::endl;
+        disp << margin << "Module Id: " << module_id << std::endl;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCModuleLinkDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putUInt8(position);
+    buf.putUInt16(module_id);
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCModuleLinkDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    position = buf.getUInt8();
+    module_id = buf.getUInt16();
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCModuleLinkDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"position", position, true);
+    root->setIntAttribute(u"module_id", module_id, true);
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCModuleLinkDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getIntAttribute(position, u"position", true) &&
+           element->getIntAttribute(module_id, u"module_id", true);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.cpp
@@ -17,18 +17,17 @@
 
 #define MY_XML_NAME u"dsmcc_module_link_descriptor"
 #define MY_CLASS    ts::DSMCCModuleLinkDescriptor
-#define MY_DID      ts::DID_DSMCC_MODULE_LINK
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_MODULE_LINK, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
 
 //----------------------------------------------------------------------------
 // Constructors.
 //----------------------------------------------------------------------------
 
 ts::DSMCCModuleLinkDescriptor::DSMCCModuleLinkDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
@@ -49,7 +48,7 @@ void ts::DSMCCModuleLinkDescriptor::clearContent()
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCModuleLinkDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCModuleLinkDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     if (buf.canReadBytes(3)) {
         const uint8_t  position = buf.getUInt8();

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.h
@@ -1,0 +1,54 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a module_link_descriptor (DSM-CC U-N Message DSI/DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of a module_link_descriptor (DSM-CC U-N Message DII specific).
+    //! This descriptor cannot be present in other tables than a DII (0x3B)
+    //!
+    //! @see ETSI EN 301 192 V1.7.1 (2021-08), 10.2.5
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCModuleLinkDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCModuleLinkDescriptor public members:
+        uint8_t  position = 0;   //!< Position of the module.
+        uint16_t module_id = 0;  //!< Module Id
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCModuleLinkDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCModuleLinkDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.names
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.names
@@ -1,0 +1,5 @@
+[dsmcc_module_link_descriptor.position]
+Bits = 8
+0x00 = First module of the list
+0x01 = Intermediate module in the list
+0x02 = Last module of the list

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCModuleLinkDescriptor.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_module_link_descriptor
+      position="uint8, required"
+      module_id="uint16, required">
+    </dsmcc_module_link_descriptor>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.adoc
@@ -1,0 +1,8 @@
+==== dsmcc_name_descriptor
+
+Defined by DVB in <<ETSI-301-192>>.
+
+[source,xml]
+----
+<dsmcc_name_descriptor name="string, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.cpp
@@ -1,0 +1,85 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCNameDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIBuffer.h"
+#include "tsPSIRepository.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+
+#define MY_XML_NAME u"dsmcc_name_descriptor"
+#define MY_CLASS    ts::DSMCCNameDescriptor
+#define MY_DID      ts::DID_DSMCC_NAME
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+
+//----------------------------------------------------------------------------
+// Constructors
+//----------------------------------------------------------------------------
+
+ts::DSMCCNameDescriptor::DSMCCNameDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCNameDescriptor::DSMCCNameDescriptor(DuckContext& duck, const Descriptor& desc) :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0),
+    name()
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCNameDescriptor::clearContent()
+{
+    name.clear();
+}
+
+
+//----------------------------------------------------------------------------
+// Binary serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCNameDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putString(name);
+}
+
+void ts::DSMCCNameDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    buf.getString(name);
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCNameDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    disp << margin << "Module or Group Name: \"" << buf.getString() << "\"" << std::endl;
+}
+
+
+//----------------------------------------------------------------------------
+// XML
+//----------------------------------------------------------------------------
+
+void ts::DSMCCNameDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setAttribute(u"name", name);
+}
+
+bool ts::DSMCCNameDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getAttribute(name, u"name", true, u"", 0, MAX_DESCRIPTOR_SIZE - 2);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.cpp
@@ -16,11 +16,9 @@
 
 #define MY_XML_NAME u"dsmcc_name_descriptor"
 #define MY_CLASS    ts::DSMCCNameDescriptor
-#define MY_DID      ts::DID_DSMCC_NAME
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_NAME, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
 
 
 //----------------------------------------------------------------------------
@@ -28,12 +26,12 @@ TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML
 //----------------------------------------------------------------------------
 
 ts::DSMCCNameDescriptor::DSMCCNameDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
 ts::DSMCCNameDescriptor::DSMCCNameDescriptor(DuckContext& duck, const Descriptor& desc) :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0),
+    AbstractDescriptor(MY_EDID, MY_XML_NAME),
     name()
 {
     deserialize(duck, desc);
@@ -64,7 +62,7 @@ void ts::DSMCCNameDescriptor::deserializePayload(PSIBuffer& buf)
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCNameDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCNameDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     disp << margin << "Module or Group Name: \"" << buf.getString() << "\"" << std::endl;
 }

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.h
@@ -1,0 +1,52 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a name_descriptor (DSM-CC U-N Message DSI/DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+#include "tsUString.h"
+
+namespace ts {
+    //!
+    //! Representation of a name_descriptor.
+    //! @see ETSI EN 301 192 V1.7.1 (2021-08), 10.2.3
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCNameDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCNameDescriptor public members:
+        UString name {};  //!< Name of the module or group.
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCNameDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCNameDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer& buf) const override;
+        virtual void deserializePayload(PSIBuffer& buf) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCNameDescriptor.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_name_descriptor name="string, required"/>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.adoc
@@ -1,0 +1,9 @@
+==== dsmcc_ssu_module_type_descriptor
+
+Defined by DVB in <<ETSI-102-006>>.
+
+[source,xml]
+----
+<dsmcc_ssu_module_type_descriptor
+    SSU_module_type="uint8, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.cpp
@@ -17,11 +17,9 @@
 
 #define MY_XML_NAME u"dsmcc_ssu_module_type_descriptor"
 #define MY_CLASS    ts::DSMCCSSUModuleTypeDescriptor
-#define MY_DID      ts::DID_DSMCC_SSU_MODULE_TYPE
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_SSU_MODULE_TYPE, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
 
 
 //----------------------------------------------------------------------------
@@ -29,7 +27,7 @@ TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML
 //----------------------------------------------------------------------------
 
 ts::DSMCCSSUModuleTypeDescriptor::DSMCCSSUModuleTypeDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
@@ -49,7 +47,7 @@ void ts::DSMCCSSUModuleTypeDescriptor::clearContent()
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCSSUModuleTypeDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCSSUModuleTypeDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     if (buf.canReadBytes(1)) {
         disp << margin << "SSU Module Type: " << DataName(MY_XML_NAME, u"SSU_module_type", buf.getUInt8(), NamesFlags::HEXA_FIRST) << std::endl;

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.cpp
@@ -1,0 +1,97 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCSSUModuleTypeDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+#include "tsNames.h"
+
+#define MY_XML_NAME u"dsmcc_ssu_module_type_descriptor"
+#define MY_CLASS    ts::DSMCCSSUModuleTypeDescriptor
+#define MY_DID      ts::DID_DSMCC_SSU_MODULE_TYPE
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+
+//----------------------------------------------------------------------------
+// Constructors.
+//----------------------------------------------------------------------------
+
+ts::DSMCCSSUModuleTypeDescriptor::DSMCCSSUModuleTypeDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCSSUModuleTypeDescriptor::DSMCCSSUModuleTypeDescriptor(DuckContext& duck, const Descriptor& desc) :
+    DSMCCSSUModuleTypeDescriptor()
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCSSUModuleTypeDescriptor::clearContent()
+{
+    ssu_module_type = 0;
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCSSUModuleTypeDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBytes(1)) {
+        disp << margin << "SSU Module Type: " << DataName(MY_XML_NAME, u"SSU_module_type", buf.getUInt8(), NamesFlags::HEXA_FIRST) << std::endl;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCSSUModuleTypeDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putUInt8(ssu_module_type);
+}
+
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCSSUModuleTypeDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    ssu_module_type = buf.getUInt8();
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCSSUModuleTypeDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"ssu_module_type", ssu_module_type, true);
+}
+
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCSSUModuleTypeDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getIntAttribute(ssu_module_type, u"ssu_module_type", true);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.h
@@ -1,0 +1,53 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a location_descriptor (DSM-CC U-N Message DSI/DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of a SSU_module_type_descriptor (DSM-CC U-N Message DII specific).
+    //! This descriptor cannot be present in other tables than a DII (0x3B)
+    //!
+    //! @see ETSI TS 102 006 V1.4.1 (2015-06), 8.2.1.
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCSSUModuleTypeDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCSSUModuleTypeDescriptor public members:
+        uint8_t ssu_module_type = 0;  //!< SSU Module Type
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCSSUModuleTypeDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCSSUModuleTypeDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.names
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.names
@@ -1,0 +1,6 @@
+[dsmcc_ssu_module_type_descriptor.SSU_module_type]
+Bits = 8
+0x00 = Executable module type
+0x01 = Memory mapped code module type
+0x02 = Data module type
+0x03-0xFF = Reserved for future use

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSSUModuleTypeDescriptor.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_ssu_module_type_descriptor
+      SSU_module_type ="uint8, required">
+    </dsmcc_ssu_module_type_descriptor>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.adoc
@@ -1,0 +1,9 @@
+==== dsmcc_subgroup_association_descriptor
+
+Defined by DVB in <<ETSI-102-006>>.
+Must be in a DSI (table id 0x3B).
+
+[source,xml]
+----
+<dsmcc_subgroup_association_descriptor subgroup_tag="uint40, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.cpp
@@ -66,7 +66,7 @@ void ts::DSMCCSubgroupAssociationDescriptor::deserializePayload(PSIBuffer& buf)
 void ts::DSMCCSubgroupAssociationDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
 {
     if (buf.canReadBits(40)) {
-        disp << margin << UString::Format(u"Subgroup tag: 0x%010X (%<d)", buf.getUInt40()) << std::endl;
+        disp << margin << UString::Format(u"Subgroup tag: %n", buf.getUInt40()) << std::endl;
     }
 }
 

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.cpp
@@ -16,11 +16,9 @@
 
 #define MY_XML_NAME u"dsmcc_subgroup_association_descriptor"
 #define MY_CLASS    ts::DSMCCSubgroupAssociationDescriptor
-#define MY_DID      ts::DID_DSMCC_SUBGROUP_ASSOCIATION
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_SUBGROUP_ASSOCIATION, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
 
 
 //----------------------------------------------------------------------------
@@ -28,7 +26,7 @@ TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML
 //----------------------------------------------------------------------------
 
 ts::DSMCCSubgroupAssociationDescriptor::DSMCCSubgroupAssociationDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
@@ -63,7 +61,7 @@ void ts::DSMCCSubgroupAssociationDescriptor::deserializePayload(PSIBuffer& buf)
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCSubgroupAssociationDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCSubgroupAssociationDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     if (buf.canReadBits(40)) {
         disp << margin << UString::Format(u"Subgroup tag: %n", buf.getUInt40()) << std::endl;

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.cpp
@@ -1,0 +1,86 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCSubgroupAssociationDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+
+#define MY_XML_NAME u"dsmcc_subgroup_association_descriptor"
+#define MY_CLASS    ts::DSMCCSubgroupAssociationDescriptor
+#define MY_DID      ts::DID_DSMCC_SUBGROUP_ASSOCIATION
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+
+//----------------------------------------------------------------------------
+// Constructors
+//----------------------------------------------------------------------------
+
+ts::DSMCCSubgroupAssociationDescriptor::DSMCCSubgroupAssociationDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCSubgroupAssociationDescriptor::DSMCCSubgroupAssociationDescriptor(DuckContext& duck, const Descriptor& desc) :
+    DSMCCSubgroupAssociationDescriptor()
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCSubgroupAssociationDescriptor::clearContent()
+{
+    subgroup_tag = 0;
+}
+
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCSubgroupAssociationDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putUInt40(subgroup_tag);
+}
+
+void ts::DSMCCSubgroupAssociationDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    subgroup_tag = buf.getUInt40();
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCSubgroupAssociationDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    if (buf.canReadBits(40)) {
+        disp << margin << UString::Format(u"Subgroup tag: 0x%010X (%<d)", buf.getUInt40()) << std::endl;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCSubgroupAssociationDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"subgroup_tag", subgroup_tag, true);
+}
+
+bool ts::DSMCCSubgroupAssociationDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getIntAttribute(subgroup_tag, u"subgroup_tag", true, 0, 0, 0x000000FFFFFFFFFF);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.h
@@ -1,0 +1,54 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of an subgroup_association_descriptor (DSM-CC U-N Message DSI specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of a subgroup_association_descriptor (DSM-CC U-N Message DSI specific).
+    //!
+    //! This descriptor cannot be present in other tables than a DSI
+    //!
+    //! @see ETSI TS 102 006, 9.6.2.1
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCSubgroupAssociationDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCSubgroupAssociationDescriptor public members:
+        uint64_t subgroup_tag = 0;  //!< 40 bits, subgroup tag
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCSubgroupAssociationDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCSubgroupAssociationDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCSubgroupAssociationDescriptor.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_subgroup_association_descriptor subgroup_tag="uint40, required"/>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.adoc
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.adoc
@@ -1,0 +1,8 @@
+==== dsmcc_type_descriptor
+
+Defined by DVB in <<ETSI-301-192>>.
+
+[source,xml]
+----
+<dsmcc_type_descriptor type="string, required"/>
+----

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.cpp
@@ -1,0 +1,84 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCTypeDescriptor.h"
+#include "tsDescriptor.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIBuffer.h"
+#include "tsPSIRepository.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+
+#define MY_XML_NAME u"dsmcc_type_descriptor"
+#define MY_CLASS    ts::DSMCCTypeDescriptor
+#define MY_DID      ts::DID_DSMCC_TYPE
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::DVB
+
+TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+
+
+//----------------------------------------------------------------------------
+// Constructors
+//----------------------------------------------------------------------------
+
+ts::DSMCCTypeDescriptor::DSMCCTypeDescriptor() :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+}
+
+ts::DSMCCTypeDescriptor::DSMCCTypeDescriptor(DuckContext& duck, const Descriptor& desc) :
+    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+{
+    deserialize(duck, desc);
+}
+
+void ts::DSMCCTypeDescriptor::clearContent()
+{
+    type.clear();
+}
+
+
+//----------------------------------------------------------------------------
+// Binary serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCTypeDescriptor::serializePayload(PSIBuffer& buf) const
+{
+    buf.putString(type);
+}
+
+void ts::DSMCCTypeDescriptor::deserializePayload(PSIBuffer& buf)
+{
+    buf.getString(type);
+}
+
+
+//----------------------------------------------------------------------------
+// Static method to display a descriptor.
+//----------------------------------------------------------------------------
+
+void ts::DSMCCTypeDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+{
+    disp << margin << "Module or Group Type: \"" << buf.getString() << "\"" << std::endl;
+}
+
+
+//----------------------------------------------------------------------------
+// XML
+//----------------------------------------------------------------------------
+
+void ts::DSMCCTypeDescriptor::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setAttribute(u"type", type);
+}
+
+bool ts::DSMCCTypeDescriptor::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getAttribute(type, u"type", true, u"", 0, MAX_DESCRIPTOR_SIZE - 2);
+}

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.cpp
@@ -7,6 +7,7 @@
 //----------------------------------------------------------------------------
 
 #include "tsDSMCCTypeDescriptor.h"
+#include "tsDSMCCSubgroupAssociationDescriptor.h"
 #include "tsDescriptor.h"
 #include "tsTablesDisplay.h"
 #include "tsPSIBuffer.h"
@@ -16,11 +17,9 @@
 
 #define MY_XML_NAME u"dsmcc_type_descriptor"
 #define MY_CLASS    ts::DSMCCTypeDescriptor
-#define MY_DID      ts::DID_DSMCC_TYPE
-#define MY_TID      ts::TID_DSMCC_UNM
-#define MY_STD      ts::Standards::DVB
+#define MY_EDID     ts::EDID::TableSpecific(ts::DID_DSMCC_TYPE, ts::Standards::DVB, ts::TID_DSMCC_UNM)
 
-TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML_NAME, MY_CLASS::DisplayDescriptor);
+TS_REGISTER_DESCRIPTOR(MY_CLASS, MY_EDID, MY_XML_NAME, MY_CLASS::DisplayDescriptor);
 
 
 //----------------------------------------------------------------------------
@@ -28,12 +27,12 @@ TS_REGISTER_DESCRIPTOR(MY_CLASS, ts::EDID::TableSpecific(MY_DID, MY_TID), MY_XML
 //----------------------------------------------------------------------------
 
 ts::DSMCCTypeDescriptor::DSMCCTypeDescriptor() :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
 }
 
 ts::DSMCCTypeDescriptor::DSMCCTypeDescriptor(DuckContext& duck, const Descriptor& desc) :
-    AbstractDescriptor(MY_DID, MY_XML_NAME, MY_STD, 0)
+    AbstractDescriptor(MY_EDID, MY_XML_NAME)
 {
     deserialize(duck, desc);
 }
@@ -63,7 +62,7 @@ void ts::DSMCCTypeDescriptor::deserializePayload(PSIBuffer& buf)
 // Static method to display a descriptor.
 //----------------------------------------------------------------------------
 
-void ts::DSMCCTypeDescriptor::DisplayDescriptor(TablesDisplay& disp, PSIBuffer& buf, const UString& margin, DID did, TID tid, PDS pds)
+void ts::DSMCCTypeDescriptor::DisplayDescriptor(TablesDisplay& disp, const ts::Descriptor& desc, PSIBuffer& buf, const UString& margin, const ts::DescriptorContext& context)
 {
     disp << margin << "Module or Group Type: \"" << buf.getString() << "\"" << std::endl;
 }

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.h
@@ -1,0 +1,52 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2024, Thierry Lelegard
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of a type_descriptor (DSM-CC U-N Message DSI/DII specific).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractDescriptor.h"
+#include "tsUString.h"
+
+namespace ts {
+    //!
+    //! Representation of a type_descriptor.
+    //! @see ETSI EN 301 192 V1.7.1 (2021-08), 10.2.2
+    //! @ingroup descriptor
+    //!
+    class TSDUCKDLL DSMCCTypeDescriptor: public AbstractDescriptor {
+    public:
+        // DSMCCTypeDescriptor public members:
+        UString type {};  //!< Type of the module or group.
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCTypeDescriptor();
+
+        //!
+        //! Constructor from a binary descriptor
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] bin A binary descriptor to deserialize.
+        //!
+        DSMCCTypeDescriptor(DuckContext& duck, const Descriptor& bin);
+
+        // Inherited methods
+        DeclareDisplayDescriptor();
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(PSIBuffer& buf) const override;
+        virtual void deserializePayload(PSIBuffer& buf) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext&, const xml::Element*) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.h
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2005-2024, Thierry Lelegard
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.xml
+++ b/src/libtsduck/dtv/descriptors/dvb/tsDSMCCTypeDescriptor.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_descriptors>
+
+    <dsmcc_type_descriptor type="string, required"/>
+
+  </_descriptors>
+</tsduck>

--- a/src/libtsduck/dtv/signalization/tsDID.h
+++ b/src/libtsduck/dtv/signalization/tsDID.h
@@ -188,6 +188,25 @@ namespace ts {
         DID_AIT_APP_USAGE       = 0x16,  //!< DID for AIT application_usage_descriptor.
         DID_AIT_APP_BOUNDARY    = 0x17,  //!< DID for AIT simple_application_boundary_descriptor.
 
+        // Valid in DVB data carousel context (ISO/IEC 13818-6, ETSI EN 301 192, ETSI TR 101 202, ETSI TS 102 809):
+
+        DID_DSMCC_TYPE                 = 0x01, //!< DID for DSM-CC U-N Message DSI/DII type_descriptor.
+        DID_DSMCC_NAME                 = 0x02, //!< DID for DSM-CC U-N Message DSI/DII name_descriptor.
+        DID_DSMCC_INFO                 = 0x03, //!< DID for DSM-CC U-N Message DSI/DII info_descriptor.
+        DID_DSMCC_MODULE_LINK          = 0x04, //!< DID for DSM-CC U-N Message DII module_link_descriptor.
+        DID_DSMCC_CRC32                = 0x05, //!< DID for DSM-CC U-N Message DII CRC32_descriptor.
+        DID_DSMCC_LOCATION             = 0x06, //!< DID for DSM-CC U-N Message DSI/DII location_descriptor.
+        DID_DSMCC_EST_DOWNLOAD_TIME    = 0x07, //!< DID for DSM-CC U-N Message DSI/DII est_download_time_descriptor.
+        DID_DSMCC_GROUP_LINK           = 0x08, //!< DID for DSM-CC U-N Message DSI group_link_descriptor.
+        DID_DSMCC_COMPRESSED_MODULE    = 0x09, //!< DID for DSM-CC U-N Message DII compressed_module_descriptor.
+        DID_DSMCC_SSU_MODULE_TYPE      = 0x0A, //!< DID for DSM-CC U-N Message DII ssu_module_type_descriptor.
+        DID_DSMCC_SUBGROUP_ASSOCIATION = 0x0B, //!< DID for DSM-CC U-N Message DSI subgroup_association_descriptor.
+
+        // Valid in DVB MHP/HbbTV object carousel context (ETSI TS 102 727, ETSI TS 102 809):
+
+        DID_DSMCC_LABEL             = 0x70, //!< DID for DSM-CC U-N Message DII label_descriptor.
+        DID_DSMCC_CACHING_PRIORITY  = 0x71, //!< DID for DSM-CC U-N Message DII caching_priority_descriptor.
+
         // Valid only in a DVB INT (IP/MAC Notification Table, ETSI EN 301 192):
 
         DID_INT_SMARTCARD      = 0x06,  //!< DID for INT target_smartcard_descriptor

--- a/src/libtsduck/dtv/signalization/tsDID.names
+++ b/src/libtsduck/dtv/signalization/tsDID.names
@@ -163,7 +163,7 @@ Extended = true
 # MPEG private descriptor with "AV01" registration id.
 # Descriptors are defined by the Alliance for Open Media.
 # Also used as DVB private descriptors with PDS for AOM ("AOMS").
-# 
+#
 0x0001_01_41563031_80 = AV1 Video
 #
 # MPEG pivate descriptor with "AVSA" registration is.
@@ -281,6 +281,24 @@ Extended = true
 # Valid in a PMT (0x02):
 #
 0x0002_03_FFFFFF_02_A7 = RCS content (ETSI EN 301 790)
+#
+# DVB table-specific descriptors.
+# Valid in a DSM-CC UNM (0x3B, DSM-CC User-to-Network Message, ETSI EN 301 192)
+#
+0x0002_03_FFFFFF_3B_01 = DSM-CC U-N Message Type
+0x0002_03_FFFFFF_3B_02 = DSM-CC U-N Message Name
+0x0002_03_FFFFFF_3B_03 = DSM-CC U-N Message Info
+0x0002_03_FFFFFF_3B_04 = DSM-CC U-M Message Module Link
+0x0002_03_FFFFFF_3B_05 = DSM-CC U-N Message CRC32
+0x0002_03_FFFFFF_3B_06 = DSM-CC U-N Message Location
+0x0002_03_FFFFFF_3B_07 = DSM-CC U-N Message Estimated Download Time
+0x0002_03_FFFFFF_3B_08 = DSM-CC U-N Message Group Link
+0x0002_03_FFFFFF_3B_09 = DSM-CC U-N Message Compressed Module
+0x0002_03_FFFFFF_3B_0A = DSM-CC U-N Message SSU Module Type
+0x0002_03_FFFFFF_3B_0B = DSM-CC U-N Message Subgroup Association
+0x0002_03_FFFFFF_3B_70 = DSM-CC U-N Message Label
+0x0002_03_FFFFFF_3B_71 = DSM-CC U-N Message Caching Priority
+0x0002_03_FFFFFF_3B_72 = DSM-CC U-N Message Content Type
 #
 # DVB table-specific descriptors.
 # Valid in a UNT (0x4B, Update Notification Table, ETSI TS 102 006):
@@ -529,7 +547,7 @@ Extended = true
 # DVB private descriptors with PDS for AOM ("AOMS").
 # Descriptors are defined by the Alliance for Open Media.
 # Also used as MPEG private descriptor with "AV01" registration id.
-# 
+#
 0x0002_01_414F4D53_80 = AV1 Video
 #
 # Dual private descriptors with REGID/PDS for AVS audio.

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.adoc
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.adoc
@@ -7,12 +7,13 @@ Defined by MPEG in <<ISO-13818-6>>.
 <DSMCC_download_data_message
     version="uint5, default=0"
     current="bool, default=true"
+    table_id_extension="uint16, default=0xFFFF"
     protocol_discriminator="uint8, required"
     dsmcc_type="uint8, required"
     message_id="uint16, required"
     download_id="uint32, required"
     module_id="uint16, required"
-    module_version="uint8, required"
+    module_version="uint8, required">
   <block_data>
     Hexadecimal content
   </block_data>

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.adoc
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.adoc
@@ -1,0 +1,20 @@
+==== DSM-CC Download Data Message
+
+Defined by MPEG in <<ISO-13818-6>>.
+
+[source,xml]
+----
+<DSMCC_download_data_message
+    version="uint5, default=0"
+    current="bool, default=true"
+    protocol_discriminator="uint8, required"
+    dsmcc_type="uint8, required"
+    message_id="uint16, required"
+    download_id="uint32, required"
+    module_id="uint16, required"
+    module_version="uint8, required"
+  <block_data>
+    Hexadecimal content
+  </block_data>
+</DSMCC_download_data_message>
+----

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.cpp
@@ -1,0 +1,196 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2018-2024, Tristan Claverie
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCDownloadDataMessage.h"
+#include "tsBinaryTable.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+
+#define MY_XML_NAME u"DSMCC_download_data_message"
+#define MY_CLASS    ts::DSMCCDownloadDataMessage
+#define MY_TID      ts::TID_DSMCC_DDM
+#define MY_STD      ts::Standards::MPEG
+
+TS_REGISTER_TABLE(MY_CLASS, {MY_TID}, MY_STD, MY_XML_NAME, MY_CLASS::DisplaySection);
+
+
+//----------------------------------------------------------------------------
+// Constructors and assignment.
+//----------------------------------------------------------------------------
+
+ts::DSMCCDownloadDataMessage::DSMCCDownloadDataMessage(uint8_t vers, bool cur) :
+    AbstractLongTable(MY_TID, MY_XML_NAME, MY_STD, vers, cur)
+{
+}
+
+ts::DSMCCDownloadDataMessage::DSMCCDownloadDataMessage(DuckContext& duck, const BinaryTable& table) :
+    DSMCCDownloadDataMessage(0, true)
+{
+    deserialize(duck, table);
+}
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCDownloadDataMessage::clearContent()
+{
+    protocol_discriminator = 0x11;
+    dsmcc_type = 0x00;
+    message_id = 0;
+    download_id = 0;
+    module_id = 0;
+    module_version = 0;
+    block_number = 0;
+    block_data.clear();
+}
+
+uint16_t ts::DSMCCDownloadDataMessage::tableIdExtension() const
+{
+    return module_id;
+}
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCDownloadDataMessage::deserializePayload(PSIBuffer& buf, const Section& section)
+{
+    protocol_discriminator = buf.getUInt8();
+    dsmcc_type = buf.getUInt8();
+    message_id = buf.getUInt16();
+    download_id = buf.getUInt32();
+
+    buf.skipBytes(1);
+
+    uint8_t adaptation_length = buf.getUInt8();
+
+    // Skip message length
+    buf.skipBytes(2);
+    /*uint16_t message_length = buf.getUInt16();*/
+
+    /* For object carousel it should be 0 */
+    if (adaptation_length > 0) {
+        buf.skipBytes(adaptation_length);
+    }
+
+    module_id = buf.getUInt16();
+    module_version = buf.getUInt8();
+
+    // Reserved
+    buf.skipBytes(1);
+
+    block_number = buf.getUInt16();
+    buf.getBytesAppend(block_data);
+}
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+void ts::DSMCCDownloadDataMessage::serializePayload(BinaryTable& table, PSIBuffer& buf) const
+{
+    buf.putUInt8(protocol_discriminator);
+    buf.putUInt8(dsmcc_type);
+    buf.putUInt16(message_id);
+    buf.putUInt32(download_id);
+    buf.putUInt16(module_id);
+    buf.putUInt8(module_version);
+    buf.putUInt16(block_number);
+    buf.pushState();
+
+    // Loop on new sections until all block bytes are gone.
+    size_t block_data_index = 0;
+    while (table.sectionCount() == 0 || block_data_index < block_data.size()) {
+        block_data_index += buf.putBytes(block_data, block_data_index, std::min(block_data.size() - block_data_index, buf.remainingWriteBytes()));
+        addOneSection(table, buf);
+    }
+}
+
+void ts::DSMCCDownloadDataMessage::DisplaySection(TablesDisplay& disp, const ts::Section& section, PSIBuffer& buf, const UString& margin)
+{
+    /*uint16_t message_length = 0;*/
+    uint8_t adaptation_length = 0;
+
+    if (buf.canReadBytes(12)) {
+        const uint8_t  protocol_discriminator = buf.getUInt8();
+        const uint8_t  dsmcc_type = buf.getUInt8();
+        const uint16_t message_id = buf.getUInt16();
+        const uint32_t download_id = buf.getUInt32();
+
+        // Skip reserved
+        buf.skipBytes(1);
+
+        adaptation_length = buf.getUInt8();
+        // Skip message length
+        /*message_length = buf.getUInt16();*/
+        buf.skipBytes(2);
+
+        /* For object carousel it should be 0 */
+        if (adaptation_length > 0) {
+            buf.skipBytes(adaptation_length);
+        }
+
+        disp << margin << UString::Format(u"Protocol discriminator: %n", protocol_discriminator) << std::endl;
+        disp << margin << "Dsmcc type: " << DataName(MY_XML_NAME, u"dsmcc_type", dsmcc_type, NamesFlags::HEXA_FIRST) << std::endl;
+        if (dsmcc_type == 0x03) {
+            disp << margin << "Message id: " << DataName(MY_XML_NAME, u"message_id", message_id, NamesFlags::HEXA_FIRST) << std::endl;
+        }
+        else {
+            disp << margin << UString::Format(u"Message id: %n", message_id) << std::endl;
+        }
+        disp << margin << UString::Format(u"Download id: %n", download_id) << std::endl;
+    }
+
+    if (buf.canReadBytes(6)) {
+        const uint16_t module_id = buf.getUInt16();
+        const uint8_t  module_version = buf.getUInt8();
+
+        buf.skipBytes(1);
+
+        const uint16_t block_number = buf.getUInt16();
+
+        disp << margin << UString::Format(u"Module id: %n", module_id) << std::endl;
+        disp << margin << UString::Format(u"Module version: %n", module_version) << std::endl;
+        disp << margin << UString::Format(u"Block number: %n", block_number) << std::endl;
+
+        disp.displayPrivateData(u"Block data:", buf, NPOS, margin);
+    }
+}
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCDownloadDataMessage::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"protocol_discriminator", protocol_discriminator, true);
+    root->setIntAttribute(u"dsmcc_type", dsmcc_type, true);
+    root->setIntAttribute(u"message_id", message_id, true);
+    root->setIntAttribute(u"download_id", download_id, true);
+    root->setIntAttribute(u"module_id", module_id, true);
+    root->setIntAttribute(u"module_version", module_version, true);
+    root->addHexaTextChild(u"block_data", block_data, true);
+}
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCDownloadDataMessage::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    return element->getIntAttribute(protocol_discriminator, u"protocol_discriminator", false, 0x11) &&
+           element->getIntAttribute(dsmcc_type, u"dsmcc_type", true, 0x03) &&
+           element->getIntAttribute(message_id, u"message_id", true) &&
+           element->getIntAttribute(download_id, u"download_id", true) &&
+           element->getIntAttribute(module_id, u"module_id", true) &&
+           element->getIntAttribute(module_version, u"module_version", true) &&
+           element->getHexaTextChild(block_data, u"block_data");
+}

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2018-2024, Tristan Claverie
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.cpp
@@ -53,6 +53,15 @@ void ts::DSMCCDownloadDataMessage::clearContent()
     block_data.clear();
 }
 
+//----------------------------------------------------------------------------
+// Inherited public methods
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCDownloadDataMessage::isPrivate() const
+{
+    return false;  // MPEG-defined
+}
+
 uint16_t ts::DSMCCDownloadDataMessage::tableIdExtension() const
 {
     return module_id;
@@ -69,13 +78,11 @@ void ts::DSMCCDownloadDataMessage::deserializePayload(PSIBuffer& buf, const Sect
     message_id = buf.getUInt16();
     download_id = buf.getUInt32();
 
-    buf.skipBytes(1);
+    buf.skipBytes(1);  // reserved
 
     uint8_t adaptation_length = buf.getUInt8();
 
-    // Skip message length
-    buf.skipBytes(2);
-    /*uint16_t message_length = buf.getUInt16();*/
+    buf.skipBytes(2);  // message_length
 
     /* For object carousel it should be 0 */
     if (adaptation_length > 0) {
@@ -85,8 +92,7 @@ void ts::DSMCCDownloadDataMessage::deserializePayload(PSIBuffer& buf, const Sect
     module_id = buf.getUInt16();
     module_version = buf.getUInt8();
 
-    // Reserved
-    buf.skipBytes(1);
+    buf.skipBytes(1);  // reserved
 
     block_number = buf.getUInt16();
     buf.getBytesAppend(block_data);

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.cpp
@@ -44,9 +44,9 @@ ts::DSMCCDownloadDataMessage::DSMCCDownloadDataMessage(DuckContext& duck, const 
 void ts::DSMCCDownloadDataMessage::clearContent()
 {
     table_id_ext = 0;
-    protocol_discriminator = 0x11;
-    dsmcc_type = 0x00;
-    message_id = 0;
+    protocol_discriminator = DSMCC_PROTOCOL_DISCRIMINATOR;
+    dsmcc_type = DSMCC_TYPE_DOWNLOAD_MESSAGE;
+    message_id = DSMCC_MESSAGE_ID_DDB;
     download_id = 0;
     module_id = 0;
     module_version = 0;
@@ -95,7 +95,7 @@ void ts::DSMCCDownloadDataMessage::deserializePayload(PSIBuffer& buf, const Sect
 
     buf.skipBytes(2);  // message_length
 
-    /* For object carousel it should be 0 */
+    // For object carousel it should be 0
     if (adaptation_length > 0) {
         buf.skipBytes(adaptation_length);
     }
@@ -151,7 +151,7 @@ void ts::DSMCCDownloadDataMessage::DisplaySection(TablesDisplay& disp, const ts:
 
     disp << margin << UString::Format(u"Table extension id: %n", tidext) << std::endl;
 
-    if (buf.canReadBytes(12)) {
+    if (buf.canReadBytes(DOWNLOAD_DATA_HEADER_SIZE)) {
         const uint8_t  protocol_discriminator = buf.getUInt8();
         const uint8_t  dsmcc_type = buf.getUInt8();
         const uint16_t message_id = buf.getUInt16();
@@ -163,14 +163,14 @@ void ts::DSMCCDownloadDataMessage::DisplaySection(TablesDisplay& disp, const ts:
 
         buf.skipBytes(2);  // message_length
 
-        /* For object carousel it should be 0 */
+        // For object carousel it should be 0
         if (adaptation_length > 0) {
             buf.skipBytes(adaptation_length);
         }
 
         disp << margin << UString::Format(u"Protocol discriminator: %n", protocol_discriminator) << std::endl;
         disp << margin << "Dsmcc type: " << DataName(MY_XML_NAME, u"dsmcc_type", dsmcc_type, NamesFlags::HEXA_FIRST) << std::endl;
-        if (dsmcc_type == 0x03) {
+        if (dsmcc_type == DSMCC_TYPE_DOWNLOAD_MESSAGE) {
             disp << margin << "Message id: " << DataName(MY_XML_NAME, u"message_id", message_id, NamesFlags::HEXA_FIRST) << std::endl;
         }
         else {

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
@@ -1,0 +1,62 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2018-2024, Tristan Claverie
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of an DSM-CC Download Data Block Table (DSMCCDownloadDataMessage)
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractLongTable.h"
+
+namespace ts {
+    //!
+    //! Representation of an DSM-CC Download Data Message Table (DSMCCDownloadDataMessage)
+    //!
+    //! @see ISO/IEC 13818-6, ITU-T Rec. 9.2.2 and 9.2.7. ETSI TR 101 202 V1.2.1 (2003-01), A.2, A.5, B.
+    //! @ingroup table
+    //!
+    class TSDUCKDLL DSMCCDownloadDataMessage: public AbstractLongTable {
+    public:
+        // DSMCCDownloadDataMessage public members:
+        uint8_t   protocol_discriminator = 0x11;  //!< Indicates that the message is MPEG-2 DSM-CC message.
+        uint8_t   dsmcc_type = 0x03;              //!< Indicates type of MPEG-2 DSM-CC message.
+        uint16_t  message_id = 0;                 //!< Indicates type of message which is being passed.
+        uint32_t  download_id = 0;                //!< Used to associate the download data messages and the download control messages of a single instance of a download scenario.
+        uint16_t  module_id = 0;                  //!< Identifies to which module this block belongs.
+        uint8_t   module_version = 0;             //!< Identifies the version of the module to which this block belongs.
+        uint16_t  block_number = 0;               //!< Identifies the position of this block within the module.
+        ByteBlock block_data {};                  //!< Conveys the data of the block.
+
+        //!
+        //! Default constructor.
+        //! @param [in] vers Table version number.
+        //! @param [in] cur True if table is current, false if table is next.
+        //!
+        DSMCCDownloadDataMessage(uint8_t vers = 0, bool cur = true);
+
+        //!
+        //! Constructor from a binary table.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] table Binary table to deserialize.
+        //!
+        DSMCCDownloadDataMessage(DuckContext& duck, const BinaryTable& table);
+
+        // Inherited methods
+        DeclareDisplaySection();
+        virtual uint16_t tableIdExtension() const override;
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(BinaryTable&, PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&, const Section&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext& duck, const xml::Element* element) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
@@ -18,11 +18,15 @@ namespace ts {
     //!
     //! Representation of an DSM-CC Download Data Message Table (DSMCCDownloadDataMessage)
     //!
-    //! @see ISO/IEC 13818-6, ITU-T Rec. 9.2.2 and 9.2.7. ETSI TR 101 202 V1.2.1 (2003-01), A.2, A.5, B.
+    //! @see ISO/IEC 13818-6, ITU-T Rec. 9.2.2 and 9.2.7. ETSI TR 101 202 V1.2.1 (2003-01), A.2, A.5, B
     //! @ingroup table
     //!
     class TSDUCKDLL DSMCCDownloadDataMessage: public AbstractLongTable {
     public:
+        //!
+        //! Representation of Download Data Header
+        //! @see ETSI TR 101 202 V1.2.1 (2003-01), A.2
+        //!
         class TSDUCKDLL DownloadDataHeader {
             TS_DEFAULT_COPY_MOVE(DownloadDataHeader);
 
@@ -44,8 +48,8 @@ namespace ts {
             void clear();
         };
 
-        uint16_t           table_id_ext = 0;    //!< Module Id where block belongs
-        DownloadDataHeader header {};           //!< DSM-CC Download Data Header
+        uint16_t           table_id_ext = 0;    //!< Module Id where block belongs.
+        DownloadDataHeader header {};           //!< DSM-CC Download Data Header.
         uint16_t           module_id = 0;       //!< Identifies to which module this block belongs.
         uint8_t            module_version = 0;  //!< Identifies the version of the module to which this block belongs.
         ByteBlock          block_data {};       //!< Conveys the data of the block.
@@ -79,10 +83,10 @@ namespace ts {
         virtual bool   analyzeXML(DuckContext& duck, const xml::Element* element) override;
 
     private:
-        static constexpr size_t DOWNLOAD_DATA_HEADER_SIZE = 12;  //!< DSM-CC Download Data Header size w/o adaptation header
+        static constexpr size_t DOWNLOAD_DATA_HEADER_SIZE = 12;  //!< DSM-CC Download Data Header size w/o adaptation header.
 
-        static constexpr uint8_t  DSMCC_PROTOCOL_DISCRIMINATOR = 0x11;  //!< Protocol Discriminator for DSM-CC
-        static constexpr uint8_t  DSMCC_TYPE_DOWNLOAD_MESSAGE = 0x03;   //!< MPEG-2 DSM-CC Download Message
-        static constexpr uint16_t DSMCC_MESSAGE_ID_DDB = 0x1003;        //!< DownloadDataMessage
+        static constexpr uint8_t  DSMCC_PROTOCOL_DISCRIMINATOR = 0x11;  //!< Protocol Discriminator for DSM-CC.
+        static constexpr uint8_t  DSMCC_TYPE_DOWNLOAD_MESSAGE = 0x03;   //!< MPEG-2 DSM-CC Download Message.
+        static constexpr uint16_t DSMCC_MESSAGE_ID_DDB = 0x1003;        //!< DownloadDataMessage.
     };
 }  // namespace ts

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2018-2024, Tristan Claverie
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------
@@ -24,13 +24,13 @@ namespace ts {
     class TSDUCKDLL DSMCCDownloadDataMessage: public AbstractLongTable {
     public:
         // DSMCCDownloadDataMessage public members:
+        uint16_t  table_id_ext = 0;               //!< Module Id where block belongs
         uint8_t   protocol_discriminator = 0x11;  //!< Indicates that the message is MPEG-2 DSM-CC message.
         uint8_t   dsmcc_type = 0x03;              //!< Indicates type of MPEG-2 DSM-CC message.
         uint16_t  message_id = 0;                 //!< Indicates type of message which is being passed.
         uint32_t  download_id = 0;                //!< Used to associate the download data messages and the download control messages of a single instance of a download scenario.
         uint16_t  module_id = 0;                  //!< Identifies to which module this block belongs.
         uint8_t   module_version = 0;             //!< Identifies the version of the module to which this block belongs.
-        uint16_t  block_number = 0;               //!< Identifies the position of this block within the module.
         ByteBlock block_data {};                  //!< Conveys the data of the block.
 
         //!
@@ -54,10 +54,11 @@ namespace ts {
 
     protected:
         // Inherited methods
-        virtual void clearContent() override;
-        virtual void serializePayload(BinaryTable&, PSIBuffer&) const override;
-        virtual void deserializePayload(PSIBuffer&, const Section&) override;
-        virtual void buildXML(DuckContext&, xml::Element*) const override;
-        virtual bool analyzeXML(DuckContext& duck, const xml::Element* element) override;
+        virtual void   clearContent() override;
+        virtual size_t maxPayloadSize() const override;
+        virtual void   serializePayload(BinaryTable&, PSIBuffer&) const override;
+        virtual void   deserializePayload(PSIBuffer&, const Section&) override;
+        virtual void   buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool   analyzeXML(DuckContext& duck, const xml::Element* element) override;
     };
 }  // namespace ts

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
@@ -24,14 +24,14 @@ namespace ts {
     class TSDUCKDLL DSMCCDownloadDataMessage: public AbstractLongTable {
     public:
         // DSMCCDownloadDataMessage public members:
-        uint16_t  table_id_ext = 0;               //!< Module Id where block belongs
-        uint8_t   protocol_discriminator = 0x11;  //!< Indicates that the message is MPEG-2 DSM-CC message.
-        uint8_t   dsmcc_type = 0x03;              //!< Indicates type of MPEG-2 DSM-CC message.
-        uint16_t  message_id = 0;                 //!< Indicates type of message which is being passed.
-        uint32_t  download_id = 0;                //!< Used to associate the download data messages and the download control messages of a single instance of a download scenario.
-        uint16_t  module_id = 0;                  //!< Identifies to which module this block belongs.
-        uint8_t   module_version = 0;             //!< Identifies the version of the module to which this block belongs.
-        ByteBlock block_data {};                  //!< Conveys the data of the block.
+        uint16_t  table_id_ext = 0;                                       //!< Module Id where block belongs
+        uint8_t   protocol_discriminator = DSMCC_PROTOCOL_DISCRIMINATOR;  //!< Indicates that the message is MPEG-2 DSM-CC message.
+        uint8_t   dsmcc_type = DSMCC_TYPE_DOWNLOAD_MESSAGE;               //!< Indicates type of MPEG-2 DSM-CC message.
+        uint16_t  message_id = DSMCC_MESSAGE_ID_DDB;                      //!< Indicates type of message which is being passed.
+        uint32_t  download_id = 0;                                        //!< Used to associate the download data messages and the download control messages of a single instance of a download scenario.
+        uint16_t  module_id = 0;                                          //!< Identifies to which module this block belongs.
+        uint8_t   module_version = 0;                                     //!< Identifies the version of the module to which this block belongs.
+        ByteBlock block_data {};                                          //!< Conveys the data of the block.
 
         //!
         //! Default constructor.
@@ -60,5 +60,12 @@ namespace ts {
         virtual void   deserializePayload(PSIBuffer&, const Section&) override;
         virtual void   buildXML(DuckContext&, xml::Element*) const override;
         virtual bool   analyzeXML(DuckContext& duck, const xml::Element* element) override;
+
+    private:
+        static constexpr size_t DOWNLOAD_DATA_HEADER_SIZE = 12;  //!< DSM-CC Download Data Header size w/o adaptation header
+
+        static constexpr uint8_t  DSMCC_PROTOCOL_DISCRIMINATOR = 0x11;  //!< Protocol Discriminator for DSM-CC
+        static constexpr uint8_t  DSMCC_TYPE_DOWNLOAD_MESSAGE = 0x03;   //!< MPEG-2 DSM-CC Download Message
+        static constexpr uint16_t DSMCC_MESSAGE_ID_DDB = 0x1003;        //!< DownloadDataMessage
     };
 }  // namespace ts

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
@@ -49,6 +49,7 @@ namespace ts {
 
         // Inherited methods
         DeclareDisplaySection();
+        virtual bool     isPrivate() const override;
         virtual uint16_t tableIdExtension() const override;
 
     protected:

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
@@ -23,15 +23,32 @@ namespace ts {
     //!
     class TSDUCKDLL DSMCCDownloadDataMessage: public AbstractLongTable {
     public:
-        // DSMCCDownloadDataMessage public members:
-        uint16_t  table_id_ext = 0;                                       //!< Module Id where block belongs
-        uint8_t   protocol_discriminator = DSMCC_PROTOCOL_DISCRIMINATOR;  //!< Indicates that the message is MPEG-2 DSM-CC message.
-        uint8_t   dsmcc_type = DSMCC_TYPE_DOWNLOAD_MESSAGE;               //!< Indicates type of MPEG-2 DSM-CC message.
-        uint16_t  message_id = DSMCC_MESSAGE_ID_DDB;                      //!< Indicates type of message which is being passed.
-        uint32_t  download_id = 0;                                        //!< Used to associate the download data messages and the download control messages of a single instance of a download scenario.
-        uint16_t  module_id = 0;                                          //!< Identifies to which module this block belongs.
-        uint8_t   module_version = 0;                                     //!< Identifies the version of the module to which this block belongs.
-        ByteBlock block_data {};                                          //!< Conveys the data of the block.
+        class TSDUCKDLL DownloadDataHeader {
+            TS_DEFAULT_COPY_MOVE(DownloadDataHeader);
+
+        public:
+            // DSMCCDownloadDataMessage public members:
+            uint8_t  protocol_discriminator = DSMCC_PROTOCOL_DISCRIMINATOR;  //!< Indicates that the message is MPEG-2 DSM-CC message.
+            uint8_t  dsmcc_type = DSMCC_TYPE_DOWNLOAD_MESSAGE;               //!< Indicates type of MPEG-2 DSM-CC message.
+            uint16_t message_id = DSMCC_MESSAGE_ID_DDB;                      //!< Indicates type of message which is being passed.
+            uint32_t download_id = 0;                                        //!< Used to associate the download data messages and the download control messages of a single instance of a download scenario.
+
+            //!
+            //! Default constructor.
+            //!
+            DownloadDataHeader() = default;
+
+            //!
+            //! Clear values.
+            //!
+            void clear();
+        };
+
+        uint16_t           table_id_ext = 0;    //!< Module Id where block belongs
+        DownloadDataHeader header {};           //!< DSM-CC Download Data Header
+        uint16_t           module_id = 0;       //!< Identifies to which module this block belongs.
+        uint8_t            module_version = 0;  //!< Identifies the version of the module to which this block belongs.
+        ByteBlock          block_data {};       //!< Conveys the data of the block.
 
         //!
         //! Default constructor.

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.names
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.names
@@ -1,0 +1,18 @@
+[DSMCC_download_data_message.dsmcc_type]
+Bits=8
+0x01 = User-to-Network configuration message
+0x02 = User-to-Network session message
+0x03 = Download message
+0x04 = SDB Channel Change Protocol message
+0x05 = User-to-Network pass-thru message
+0x80-0xFF = User Defined message type
+
+[DSMCC_download_data_message.message_id]
+# Valid only for dsmcc_type = 0x03 (Download message)
+Bits=16
+0x1001 = DownloadInfoRequest
+0x1002 = DownloadInfoIndication
+0x1003 = DownloadDataBlock
+0x1004 = DownloadDataRequest
+0x1005 = DownloadCancel
+0x1006 = DownloadServerInitiate

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.xml
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_tables>
+
+    <DSMCC_download_data_message
+        version="uint5, default=0"
+        current="bool, default=true"
+        protocol_discriminator="uint8, required"
+        dsmcc_type="uint8, required"
+        message_id="uint16, required"
+        download_id="uint32, required"
+        module_id="uint16, required"
+        module_version="uint8, required">
+      <_any in="_metadata"/>
+      <block_data>
+        Hexadecimal content
+      </block_data>
+    </DSMCC_download_data_message>
+
+  </_tables>
+</tsduck>

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.xml
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.xml
@@ -5,6 +5,7 @@
     <DSMCC_download_data_message
         version="uint5, default=0"
         current="bool, default=true"
+        table_id_extension="uint16, default=0xFFFF"
         protocol_discriminator="uint8, required"
         dsmcc_type="uint8, required"
         message_id="uint16, required"

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.adoc
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.adoc
@@ -8,33 +8,81 @@ Defined by MPEG in <<ISO-13818-6>>.
     version="uint5, default=0"
     current="bool, default=true"
     table_id_extension="uint16, default=0xFFFF"
-    protocol_discriminator="uint8, required"
-    dsmcc_type="uint8, required"
+    protocol_discriminator="uint8, required, default=0x11"
+    dsmcc_type="uint8, required, default=0x03"
     message_id="uint16, required"
     transaction_id="uint32, required">
   <DSI>
     <server_id>
       Hexadecimal content
     </server_id>
-    <private_data>
-      Hexadecimal content
-    </private_data>
+    <IOR>
+      <type_id>
+        Hexadecimal content
+      </type_id>
+      <tagged_profile profile_id_tag="uint32_t, required" profile_data_byte_order="uint8, required">
+        <!-- profile_id_tag = 0x49534F06 -->
+        <BIOP_profile_body>
+          <lite_component component_id_tag="uint32_t, required">
+            <!-- component_id_tag = 0x49534F50 (TAG_ObjectLocation) -->
+            <BIOP_object_location
+              carousel_id="uint32_t, required"
+              module_id="uint16_t, required"
+              version_major="uint8_t, required"
+              version_minor="uint8_t, required">
+              <object_key_data>
+                  Hexadecimal content
+              </object_key_data>
+            </BIOP_object_location>
+            <!-- component_id_tag = 0x49534F40 (TAG_ConnBinder) -->
+            <DSM_conn_binder>
+              <BIOP_tap
+                id="uint16, required"
+                use="uint16, required"
+                association_tag="uint16, required"
+                selector_type="uint16, required"
+                transaction_id="uint32, required"
+                timeout="uint32, required"/>
+            </DSM_conn_binder>
+            <!-- component_id_tag = other (Unknown) -->
+            <Unknown_component>
+              <component_data>
+                  Hexadecimal content
+              </component_data>
+            </Unknown_component>
+          </lite_component>
+        </BIOP_profile_body>
+        <!-- profile_id_tag = 0x49534F05 -->
+        <Lite_options_profile_body>
+          <profile_data>
+          Hexadecimal content
+          </profile_data>
+        </Lite_options_profile_body>
+        <!-- profile_id_tag = other -->
+        <Unknown_profile_body>
+          <profile_data>
+          Hexadecimal content
+          </profile_data>
+        </Unknown_profile_body>
+      </tagged_profile>
+    </IOR>
   </DSI>
   <DII
     download_id="uint32, required"
-    block_size="uint16, required"
-    number_of_modules="uint16, required">
+    block_size="uint16, required">
     <module
       module_id="uint16, required"
       module_size="uint32, required"
-      module_version="uint8, required">
-      <module_info>
-        Hexadecimal content
-      </module_info>
+      module_version="uint8, required"
+      module_timeout="uint32, required"
+      block_timeout="uint32, required"
+      min_block_time="uint32, required">
+      <tap
+        id="uint16, required"
+        use="uint16, required"
+        association_tag="uint16, required"/>
+      <DESCRIPTOR_LIST>
     </module>
-    <dii_private_data>
-      Hexadecimal content
-    </dii_private_data>
   </DII>
 </DSMCC_user_to_network_message>
 ----

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.adoc
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.adoc
@@ -1,0 +1,40 @@
+==== DSM-CC User-to-Network Message
+
+Defined by MPEG in <<ISO-13818-6>>.
+
+[source,xml]
+----
+<DSMCC_user_to_network_message
+    version="uint5, default=0"
+    current="bool, default=true"
+    table_id_extension="uint16, default=0xFFFF"
+    protocol_discriminator="uint8, required"
+    dsmcc_type="uint8, required"
+    message_id="uint16, required"
+    transaction_id="uint32, required">
+  <DSI>
+    <server_id>
+      Hexadecimal content
+    </server_id>
+    <private_data>
+      Hexadecimal content
+    </private_data>
+  </DSI>
+  <DII
+    download_id="uint32, required"
+    block_size="uint16, required"
+    number_of_modules="uint16, required">
+    <module
+      module_id="uint16, required"
+      module_size="uint32, required"
+      module_version="uint8, required">
+      <module_info>
+        Hexadecimal content
+      </module_info>
+    </module>
+    <dii_private_data>
+      Hexadecimal content
+    </dii_private_data>
+  </DII>
+</DSMCC_user_to_network_message>
+----

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
@@ -1,0 +1,318 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2018-2024, Tristan Claverie
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCUserToNetworkMessage.h"
+#include "tsBinaryTable.h"
+#include "tsTablesDisplay.h"
+#include "tsPSIRepository.h"
+#include "tsPSIBuffer.h"
+#include "tsDuckContext.h"
+#include "tsxmlElement.h"
+
+#define MY_XML_NAME u"DSMCC_user_to_network_message"
+#define MY_CLASS    ts::DSMCCUserToNetworkMessage
+#define MY_TID      ts::TID_DSMCC_UNM
+#define MY_STD      ts::Standards::MPEG
+
+TS_REGISTER_TABLE(MY_CLASS, {MY_TID}, MY_STD, MY_XML_NAME, MY_CLASS::DisplaySection);
+
+
+//----------------------------------------------------------------------------
+// Constructors and assignment.
+//----------------------------------------------------------------------------
+
+ts::DSMCCUserToNetworkMessage::DSMCCUserToNetworkMessage(uint8_t vers, bool cur) :
+    AbstractLongTable(MY_TID, MY_XML_NAME, MY_STD, vers, cur)
+{
+}
+
+ts::DSMCCUserToNetworkMessage::DSMCCUserToNetworkMessage(DuckContext& duck, const BinaryTable& table) :
+    DSMCCUserToNetworkMessage(0, true)
+{
+    deserialize(duck, table);
+}
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCUserToNetworkMessage::clearContent()
+{
+    protocol_discriminator = 0x11;
+    dsmcc_type = 0x03;
+    message_id = 0;
+    transaction_id = 0;
+
+    //DSI
+    server_id.clear();
+    private_data.clear();
+
+    //DII
+    download_id = 0;
+    block_size = 0;
+    modules.clear();
+    dii_private_data.clear();
+}
+
+uint16_t ts::DSMCCUserToNetworkMessage::tableIdExtension() const
+{
+    return 0x0000;
+}
+
+//----------------------------------------------------------------------------
+// Deserialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCUserToNetworkMessage::deserializePayload(PSIBuffer& buf, const Section& section)
+{
+    protocol_discriminator = buf.getUInt8();
+    dsmcc_type = buf.getUInt8();
+    message_id = buf.getUInt16();
+    transaction_id = buf.getUInt32();
+
+    buf.skipBytes(1);
+
+    const uint8_t adaptation_length = buf.getUInt8();
+
+    // Skip message length
+    buf.skipBytes(2);
+    /*uint16_t message_length = buf.getUInt16();*/
+
+    /* For object carousel it should be 0 */
+    if (adaptation_length > 0) {
+        buf.setUserError();
+        buf.skipBytes(adaptation_length);
+    }
+
+    if (message_id == 0x1006) {
+        buf.getBytes(server_id, SERVER_ID_SIZE);
+
+        // CompatibilityDescriptor
+        buf.skipBytes(2);
+
+        const uint16_t private_data_length = buf.getUInt16();
+
+        buf.getBytes(private_data, private_data_length);
+    }
+    else if (message_id == 0x1002) {
+        download_id = buf.getUInt32();
+        block_size = buf.getUInt16();
+
+        //windowSize + ackPeriod + tCDownloadWindow + tCDownloadScenario
+        buf.skipBytes(10);
+
+        // CompatibilityDescriptor
+        buf.skipBytes(2);
+
+        const uint16_t number_of_modules = buf.getUInt16();
+
+        for (size_t i = 0; i < number_of_modules; i++) {
+            Module module;
+            module.module_id = buf.getUInt16();
+            module.module_size = buf.getUInt32();
+            module.module_version = buf.getUInt8();
+
+            const uint8_t module_info_length = buf.getUInt8();
+
+            buf.getBytes(module.module_info, module_info_length);
+            modules.push_back(module);
+        }
+
+        const uint16_t private_data_length = buf.getUInt16();
+
+        buf.getBytes(private_data, private_data_length);
+    }
+    else {
+        buf.setUserError();
+        buf.skipBytes(buf.remainingReadBytes());
+    }
+}
+
+//----------------------------------------------------------------------------
+// Serialization
+//----------------------------------------------------------------------------
+void ts::DSMCCUserToNetworkMessage::serializePayload(BinaryTable& table, PSIBuffer& buf) const
+{
+    buf.putUInt8(protocol_discriminator);
+    buf.putUInt8(dsmcc_type);
+    buf.putUInt16(message_id);
+    buf.putUInt32(transaction_id);
+
+    if (message_id == 0x1006) {
+        buf.putBytes(server_id);
+
+        // According to ETSI TR 101 202 V1.2.1 (2003-01), 4.6.5, Table 4.1a
+        // DSI and DII messages have only one section.
+        buf.putBytes(private_data);
+    }
+    else if (message_id == 0x1002) {
+        buf.putUInt32(download_id);
+        buf.putUInt16(block_size);
+        buf.putUInt16(modules.size());
+
+        for (const auto& module : modules) {
+            buf.putUInt16(module.module_id);
+            buf.putUInt32(module.module_size);
+            buf.putUInt8(module.module_version);
+            buf.putBytes(module.module_info);
+        }
+
+        buf.putBytes(dii_private_data);
+    }
+}
+
+void ts::DSMCCUserToNetworkMessage::DisplaySection(TablesDisplay& disp, const ts::Section& section, PSIBuffer& buf, const UString& margin)
+{
+    uint8_t  adaptation_length = 0;
+    uint16_t message_id = 0;
+
+    if (buf.canReadBytes(12)) {
+        const uint8_t protocol_discriminator = buf.getUInt8();
+        const uint8_t dsmcc_type = buf.getUInt8();
+        message_id = buf.getUInt16();
+        const uint32_t transaction_id = buf.getUInt32();
+
+        // Skip reserved
+        buf.skipBytes(1);
+
+        adaptation_length = buf.getUInt8();
+
+        // Skip message length
+        /*message_length = buf.getUInt16();*/
+        buf.skipBytes(2);
+
+        /* For object carousel it should be 0 */
+        if (adaptation_length > 0) {
+            buf.skipBytes(adaptation_length);
+        }
+
+        disp << margin << UString::Format(u"Protocol discriminator: %n", protocol_discriminator) << std::endl;
+        disp << margin << "Dsmcc type: " << DataName(MY_XML_NAME, u"dsmcc_type", dsmcc_type, NamesFlags::HEXA_FIRST) << std::endl;
+        if (dsmcc_type == 0x03) {
+            disp << margin << "Message id: " << DataName(MY_XML_NAME, u"message_id", message_id, NamesFlags::HEXA_FIRST) << std::endl;
+        }
+        else {
+            disp << margin << UString::Format(u"Message id: %n", message_id) << std::endl;
+        }
+        disp << margin << UString::Format(u"Transaction id: %n", transaction_id) << std::endl;
+    }
+
+    if (message_id == 0x1006) {  //DSI
+        disp << margin << UString::Format(u"DownloadServerInitiate (DSI):") << std::endl;
+        disp.displayPrivateData(u"Server id", buf, SERVER_ID_SIZE, margin);
+
+        // CompatibilityDescriptor
+        buf.skipBytes(2);
+
+        uint16_t private_data_length = buf.getUInt16();
+
+        disp.displayPrivateData(u"Private data", buf, private_data_length, margin);
+    }
+    else if (message_id == 0x1002) {  //DII
+        disp << margin << UString::Format(u"DownloadInfoIndication (DII):") << std::endl;
+        disp << margin << UString::Format(u"Download id: %n", buf.getUInt32()) << std::endl;
+        disp << margin << UString::Format(u"Block size: %n", buf.getUInt16()) << std::endl;
+
+        //windowSize + ackPeriod + tCDownloadWindow + tCDownloadScenario
+        buf.skipBytes(10);
+
+        // CompatibilityDescriptor
+        buf.skipBytes(2);
+
+        uint16_t number_of_modules = buf.getUInt16();
+
+        for (size_t i = 0; i < number_of_modules; i++) {
+            disp << margin << UString::Format(u"Module id: %n", buf.getUInt16()) << std::endl;
+            disp << margin << UString::Format(u"Module size: %n", buf.getUInt32()) << std::endl;
+            disp << margin << UString::Format(u"Module version: %n", buf.getUInt8()) << std::endl;
+
+            uint8_t module_info_length = buf.getUInt8();
+            disp.displayPrivateData(u"Module info", buf, module_info_length, margin);
+        }
+
+        uint16_t private_data_length = buf.getUInt16();
+        disp.displayPrivateData(u"Private data", buf, private_data_length, margin);
+    }
+    else {
+        buf.setUserError();
+        disp.displayPrivateData(u"Private data", buf, NPOS, margin);
+    }
+}
+
+//----------------------------------------------------------------------------
+// XML serialization
+//----------------------------------------------------------------------------
+
+void ts::DSMCCUserToNetworkMessage::buildXML(DuckContext& duck, xml::Element* root) const
+{
+    root->setIntAttribute(u"protocol_discriminator", protocol_discriminator, true);
+    root->setIntAttribute(u"dsmcc_type", dsmcc_type, true);
+    root->setIntAttribute(u"message_id", message_id, true);
+    root->setIntAttribute(u"transaction_id", transaction_id, true);
+
+    if (message_id == 0x1006) {
+        xml::Element* dsi = root->addElement(u"DSI");
+        dsi->addHexaTextChild(u"server_id", server_id, true);
+        dsi->addHexaTextChild(u"private_data", private_data, true);
+    }
+    else if (message_id == 0x1002) {
+        xml::Element* dii = root->addElement(u"DII");
+        dii->setIntAttribute(u"download_id", download_id, true);
+        dii->setIntAttribute(u"block_size", block_size, true);
+        dii->setIntAttribute(u"number_of_modules", modules.size(), true);
+
+        for (const auto& module : modules) {
+            xml::Element* mod = dii->addElement(u"module");
+            mod->setIntAttribute(u"module_id", module.module_id, true);
+            mod->setIntAttribute(u"module_size", module.module_size, true);
+            mod->setIntAttribute(u"module_version", module.module_version, true);
+            mod->addHexaTextChild(u"module_info", module.module_info, true);
+        }
+
+        dii->addHexaTextChild(u"dii_private_data", private_data, true);
+    }
+}
+
+//----------------------------------------------------------------------------
+// XML deserialization
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCUserToNetworkMessage::analyzeXML(DuckContext& duck, const xml::Element* element)
+{
+    bool ok =
+        element->getIntAttribute(protocol_discriminator, u"protocol_discriminator", false, 0x11) &&
+        element->getIntAttribute(dsmcc_type, u"dsmcc_type", true, 0x03) &&
+        element->getIntAttribute(message_id, u"message_id", true) &&
+        element->getIntAttribute(transaction_id, u"transaction_id", true);
+
+    if (message_id == 0x1006) {
+        ok = element->getHexaTextChild(server_id, u"server_id") &&
+             element->getHexaTextChild(private_data, u"private_data");
+    }
+    else if (message_id == 0x1002) {
+        ok = element->getIntAttribute(download_id, u"download_id", true) &&
+             element->getIntAttribute(block_size, u"block_size", true);
+
+        xml::ElementVector children;
+        ok = element->getChildren(children, u"module");
+
+        for (size_t index = 0; ok && index < children.size(); ++index) {
+            Module module;
+            ok = children[index]->getIntAttribute(module.module_id, u"module_id", true) &&
+                 children[index]->getIntAttribute(module.module_size, u"module_size", true) &&
+                 children[index]->getIntAttribute(module.module_version, u"module_version", true) &&
+                 children[index]->getHexaTextChild(module.module_info, u"module_info");
+            if (ok) {
+                modules.push_back(module);
+            }
+        }
+        ok = element->getHexaTextChild(private_data, u"dii_private_data");
+    }
+
+    return ok;
+}

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
@@ -303,10 +303,10 @@ void ts::DSMCCUserToNetworkMessage::serializePayload(BinaryTable& table, PSIBuff
         buf.pushWriteSequenceWithLeadingLength(16);  // private_data
 
         // IOP::IOR
-        buf.putUInt32(ior.type_id.size());
+        buf.putUInt32(uint32_t(ior.type_id.size()));
         buf.putBytes(ior.type_id);
 
-        buf.putUInt32(ior.tagged_profiles.size());
+        buf.putUInt32(uint32_t(ior.tagged_profiles.size()));
 
         for (const auto& tagged_profile : ior.tagged_profiles) {
             buf.putUInt32(tagged_profile.profile_id_tag);
@@ -317,7 +317,7 @@ void ts::DSMCCUserToNetworkMessage::serializePayload(BinaryTable& table, PSIBuff
 
             if (tagged_profile.profile_id_tag == DSMCC_TAG_BIOP_PROFILE) {  // TAG_BIOP (BIOP Profile Body)
 
-                buf.putUInt8(tagged_profile.liteComponents.size());
+                buf.putUInt8(uint8_t(tagged_profile.liteComponents.size()));
 
                 for (const auto& liteComponent : tagged_profile.liteComponents) {
                     buf.putUInt32(liteComponent.component_id_tag);
@@ -330,7 +330,7 @@ void ts::DSMCCUserToNetworkMessage::serializePayload(BinaryTable& table, PSIBuff
                             buf.putUInt16(liteComponent.module_id);
                             buf.putUInt8(liteComponent.version_major);
                             buf.putUInt8(liteComponent.version_minor);
-                            buf.putUInt8(liteComponent.object_key_data.size());
+                            buf.putUInt8(uint8_t(liteComponent.object_key_data.size()));
                             buf.putBytes(liteComponent.object_key_data);
                             break;
                         }
@@ -391,7 +391,7 @@ void ts::DSMCCUserToNetworkMessage::serializePayload(BinaryTable& table, PSIBuff
         buf.putUInt32(0x00000000);  // tCDownloadScenario
         buf.putUInt16(0x0000);      // compatibility_descriptor_length
 
-        buf.putUInt16(modules.size());
+        buf.putUInt16(uint16_t(modules.size()));
 
         for (const auto& module : modules) {
 
@@ -407,7 +407,7 @@ void ts::DSMCCUserToNetworkMessage::serializePayload(BinaryTable& table, PSIBuff
             buf.putUInt32(module.second.block_timeout);
             buf.putUInt32(module.second.min_block_time);
 
-            buf.putUInt8(module.second.taps.size());  // taps_count
+            buf.putUInt8(uint8_t(module.second.taps.size()));  // taps_count
 
             for (const auto& tap : module.second.taps) {
                 buf.putUInt16(tap.id);

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
@@ -562,7 +562,8 @@ void ts::DSMCCUserToNetworkMessage::DisplaySection(TablesDisplay& disp, const ts
 
             uint8_t user_info_length = buf.getUInt8();
 
-            disp.displayDescriptorList(section, buf, margin, u"Descriptor List:", u"None", user_info_length);
+            DescriptorContext context(disp.duck(), section.tableId(), section.definingStandards());
+            disp.displayDescriptorList(section, context, false, buf, margin, u"Descriptor List:", u"None", user_info_length);
         }
 
         uint16_t private_data_length = buf.getUInt16();

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2018-2024, Tristan Claverie
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
@@ -1,0 +1,80 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2018-2024, Tristan Claverie
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  Representation of an DSM-CC User-to-Network Message Table (DownloadServerInitiate, DownloadInfoIndication)
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsAbstractLongTable.h"
+
+namespace ts {
+    //!
+    //! Representation of an DSM-CC User-to-Network Message Table (DownloadServerInitiate, DownloadInfoIndication)
+    //!
+    //! @see ISO/IEC 13818-6, ITU-T Rec. 9.2.2 and 9.2.7. ETSI TR 101 202 V1.2.1 (2003-01), A.1, A.3, A.4, B.
+    //! @ingroup table
+    //!
+    class TSDUCKDLL DSMCCUserToNetworkMessage: public AbstractLongTable {
+    public:
+        // DSMCCUserToNetworkMessage public members:
+        uint8_t  protocol_discriminator = 0x11;  //!< Indicates that the message is MPEG-2 DSM-CC message.
+        uint8_t  dsmcc_type = 0x03;              //!< Indicates type of MPEG-2 DSM-CC message.
+        uint16_t message_id = 0;                 //!< Indicates type of message which is being passed.
+        uint32_t transaction_id = 0;             //!< Used for session integrity and error processing.
+
+        // DownloadServerInitiate
+        static constexpr size_t SERVER_ID_SIZE = 20;  //!< Fixed size in bytes of server_id.
+        ByteBlock               server_id {};         //!< Conveys the data of the block.
+        ByteBlock               private_data {};      //!< Private data.
+
+        // DownloadInfoIndication
+        class TSDUCKDLL Module {
+        public:
+            Module() = default;  //!< Default constructor.
+            uint16_t  module_id = 0;
+            uint32_t  module_size = 0;
+            uint8_t   module_version = 0;
+            ByteBlock module_info {};
+        };
+
+        uint32_t download_id = 0;
+        uint16_t block_size = 0;
+
+        std::list<Module> modules {};  //!< Description of all transport streams.
+
+        ByteBlock dii_private_data {};  //!< Private data.
+
+        //!
+        //! Default constructor.
+        //! @param [in] vers Table version number.
+        //! @param [in] cur True if table is current, false if table is next.
+        //!
+        DSMCCUserToNetworkMessage(uint8_t vers = 0, bool cur = true);
+
+        //!
+        //! Constructor from a binary table.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] table Binary table to deserialize.
+        //!
+        DSMCCUserToNetworkMessage(DuckContext& duck, const BinaryTable& table);
+
+        // Inherited methods
+        DeclareDisplaySection();
+        virtual uint16_t tableIdExtension() const override;
+
+    protected:
+        // Inherited methods
+        virtual void clearContent() override;
+        virtual void serializePayload(BinaryTable&, PSIBuffer&) const override;
+        virtual void deserializePayload(PSIBuffer&, const Section&) override;
+        virtual void buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool analyzeXML(DuckContext& duck, const xml::Element* element) override;
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
@@ -23,17 +23,32 @@ namespace ts {
     //!
     class TSDUCKDLL DSMCCUserToNetworkMessage: public AbstractLongTable {
     public:
-        // DSMCCUserToNetworkMessage public members:
-        uint8_t  protocol_discriminator = DSMCC_PROTOCOL_DISCRIMINATOR;  //!< Indicates that the message is MPEG-2 DSM-CC message.
-        uint8_t  dsmcc_type = DSMCC_TYPE_DOWNLOAD_MESSAGE;               //!< Indicates type of MPEG-2 DSM-CC message.
-        uint16_t message_id = 0;                                         //!< Indicates type of message which is being passed.
-        uint32_t transaction_id = 0;                                     //!< Used for session integrity and error processing.
+        class TSDUCKDLL MessageHeader {
+            TS_DEFAULT_COPY_MOVE(MessageHeader);
+
+        public:
+            // DSMCCUserToNetworkMessage public members:
+            uint8_t  protocol_discriminator = DSMCC_PROTOCOL_DISCRIMINATOR;  //!< Indicates that the message is MPEG-2 DSM-CC message.
+            uint8_t  dsmcc_type = DSMCC_TYPE_DOWNLOAD_MESSAGE;               //!< Indicates type of MPEG-2 DSM-CC message.
+            uint16_t message_id = 0;                                         //!< Indicates type of message which is being passed.
+            uint32_t transaction_id = 0;                                     //!< Used for session integrity and error processing.
+
+            //!
+            //! Default constructor.
+            //!
+            MessageHeader() = default;
+
+            //!
+            //! Clear values.
+            //!
+            void clear();
+        };
 
         class TSDUCKDLL Tap {
         public:
-            Tap() = default;       //!< Default constructor.
-            uint16_t id = 0x0000;  //!< Tap Id
-            uint16_t use = 0x0016;
+            Tap() = default;        //!< Default constructor.
+            uint16_t id = 0x0000;   //!< Tap Id
+            uint16_t use = 0x0016;  //!<
             uint16_t association_tag = 0x0000;
             uint16_t selector_type = 0x0001;
             uint32_t transaction_id = 0;
@@ -82,10 +97,6 @@ namespace ts {
             std::list<TaggedProfile> tagged_profiles {};
         };
 
-
-        ByteBlock server_id {};  //!< Conveys the data of the block.
-        IOR       ior {};
-
         //  ******************************
         //  *** DownloadInfoIndication ***
         //  ******************************
@@ -104,6 +115,10 @@ namespace ts {
 
             explicit Module(const AbstractTable* table);
         };
+
+        MessageHeader header {};
+        ByteBlock     server_id {};  //!< Conveys the data of the block.
+        IOR           ior {};
 
         using ModuleList = EntryWithDescriptorsList<Module>;
 

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
@@ -29,14 +29,6 @@ namespace ts {
         uint16_t message_id = 0;                 //!< Indicates type of message which is being passed.
         uint32_t transaction_id = 0;             //!< Used for session integrity and error processing.
 
-        // DownloadServerInitiate
-        static constexpr size_t SERVER_ID_SIZE = 20;  //!< Fixed size in bytes of server_id.
-        ByteBlock               server_id {};         //!< Conveys the data of the block.
-        ByteBlock               private_data {};      //!< Private data.
-
-        //  ******************************
-        //  *** DownloadInfoIndication ***
-        //  ******************************
         class TSDUCKDLL Tap {
         public:
             Tap() = default;       //!< Default constructor.
@@ -48,16 +40,56 @@ namespace ts {
             uint32_t timeout = 0;
         };
 
-        /*class TSDUCKDLL BIOPModuleInfo: public EntryWithDescriptors {*/
-        /**/
-        /*public:*/
-        /*    //!*/
-        /*    //! Basic constructor.*/
-        /*    //! @param [in] table Parent table. A descriptor list is always attached to a table.*/
-        /*    //!*/
-        /*    explicit BIOPModuleInfo(const AbstractTable* table);*/
-        /*};*/
+        //  ******************************
+        //  *** DownloadServerInitiate ***
+        //  ******************************
+        class TSDUCKDLL LiteComponent {
+        public:
+            LiteComponent() = default;  //!< Default constructor.
+            uint32_t component_id_tag = 0;
 
+            // BIOPObjectLocation
+            uint32_t  carousel_id = 0;
+            uint16_t  module_id = 0;
+            uint8_t   version_major = 0x01;
+            uint8_t   version_minor = 0x00;
+            ByteBlock object_key_data {};
+
+            // DSMConnBinder
+            Tap tap {};
+
+            // UnknownComponent
+            ByteBlock component_data {};
+        };
+
+        class TSDUCKDLL TaggedProfile {
+        public:
+            TaggedProfile() = default;  //!< Default constructor.
+            uint32_t profile_id_tag = 0;
+            uint8_t  profile_data_byte_order = 0;
+
+            // BIOP Profile Body
+            std::list<LiteComponent> liteComponents {};
+
+            // Any other profile for now
+            ByteBlock profile_data {};
+        };
+
+        class TSDUCKDLL IOR {
+        public:
+            IOR() = default;  //!< Default constructor.
+            ByteBlock                type_id {};
+            std::list<TaggedProfile> tagged_profiles {};
+        };
+
+        static constexpr size_t SERVER_ID_SIZE = 20;  //!< Fixed size in bytes of server_id.
+
+        ByteBlock server_id {};  //!< Conveys the data of the block.
+        IOR       ior {};
+
+        //  ******************************
+        //  *** DownloadInfoIndication ***
+        //  ******************************
         class TSDUCKDLL Module: public EntryWithDescriptors {
             TS_NO_DEFAULT_CONSTRUCTORS(Module);
             TS_DEFAULT_ASSIGMENTS(Module);

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2018-2024, Tristan Claverie
+// Copyright (c) 2024, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
@@ -34,22 +34,51 @@ namespace ts {
         ByteBlock               server_id {};         //!< Conveys the data of the block.
         ByteBlock               private_data {};      //!< Private data.
 
-        // DownloadInfoIndication
-        class TSDUCKDLL Module {
+        //  ******************************
+        //  *** DownloadInfoIndication ***
+        //  ******************************
+        class TSDUCKDLL Tap {
         public:
-            Module() = default;  //!< Default constructor.
-            uint16_t  module_id = 0;
-            uint32_t  module_size = 0;
-            uint8_t   module_version = 0;
-            ByteBlock module_info {};
+            Tap() = default;       //!< Default constructor.
+            uint16_t id = 0x0000;  //!< Tap Id
+            uint16_t use = 0x0016;
+            uint16_t association_tag = 0x0000;
+            uint16_t selector_type = 0x0001;
+            uint32_t transaction_id = 0;
+            uint32_t timeout = 0;
         };
 
-        uint32_t download_id = 0;
-        uint16_t block_size = 0;
+        /*class TSDUCKDLL BIOPModuleInfo: public EntryWithDescriptors {*/
+        /**/
+        /*public:*/
+        /*    //!*/
+        /*    //! Basic constructor.*/
+        /*    //! @param [in] table Parent table. A descriptor list is always attached to a table.*/
+        /*    //!*/
+        /*    explicit BIOPModuleInfo(const AbstractTable* table);*/
+        /*};*/
 
-        std::list<Module> modules {};  //!< Description of all transport streams.
+        class TSDUCKDLL Module: public EntryWithDescriptors {
+            TS_NO_DEFAULT_CONSTRUCTORS(Module);
+            TS_DEFAULT_ASSIGMENTS(Module);
 
-        ByteBlock dii_private_data {};  //!< Private data.
+        public:
+            uint16_t       module_id = 0;
+            uint32_t       module_size = 0;
+            uint8_t        module_version = 0;
+            uint32_t       module_timeout = 0;
+            uint32_t       block_timeout = 0;
+            uint32_t       min_block_time = 0;
+            std::list<Tap> taps {};
+
+            explicit Module(const AbstractTable* table);
+        };
+
+        using ModuleList = EntryWithDescriptorsList<Module>;
+
+        uint32_t   download_id = 0;
+        uint16_t   block_size = 0;
+        ModuleList modules;
 
         //!
         //! Default constructor.

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
@@ -24,10 +24,10 @@ namespace ts {
     class TSDUCKDLL DSMCCUserToNetworkMessage: public AbstractLongTable {
     public:
         // DSMCCUserToNetworkMessage public members:
-        uint8_t  protocol_discriminator = 0x11;  //!< Indicates that the message is MPEG-2 DSM-CC message.
-        uint8_t  dsmcc_type = 0x03;              //!< Indicates type of MPEG-2 DSM-CC message.
-        uint16_t message_id = 0;                 //!< Indicates type of message which is being passed.
-        uint32_t transaction_id = 0;             //!< Used for session integrity and error processing.
+        uint8_t  protocol_discriminator = DSMCC_PROTOCOL_DISCRIMINATOR;  //!< Indicates that the message is MPEG-2 DSM-CC message.
+        uint8_t  dsmcc_type = DSMCC_TYPE_DOWNLOAD_MESSAGE;               //!< Indicates type of MPEG-2 DSM-CC message.
+        uint16_t message_id = 0;                                         //!< Indicates type of message which is being passed.
+        uint32_t transaction_id = 0;                                     //!< Used for session integrity and error processing.
 
         class TSDUCKDLL Tap {
         public:
@@ -82,7 +82,6 @@ namespace ts {
             std::list<TaggedProfile> tagged_profiles {};
         };
 
-        static constexpr size_t SERVER_ID_SIZE = 20;  //!< Fixed size in bytes of server_id.
 
         ByteBlock server_id {};  //!< Conveys the data of the block.
         IOR       ior {};
@@ -139,5 +138,18 @@ namespace ts {
         virtual void   deserializePayload(PSIBuffer&, const Section&) override;
         virtual void   buildXML(DuckContext&, xml::Element*) const override;
         virtual bool   analyzeXML(DuckContext& duck, const xml::Element* element) override;
+
+    private:
+        static constexpr size_t MESSAGE_HEADER_SIZE = 12;  //!< DSM-CC Message Header size w/o adaptation header
+        static constexpr size_t SERVER_ID_SIZE = 20;       //!< Fixed size in bytes of server_id.
+
+        static constexpr uint8_t  DSMCC_PROTOCOL_DISCRIMINATOR = 0x11;     //!< Protocol Discriminator for DSM-CC
+        static constexpr uint8_t  DSMCC_TYPE_DOWNLOAD_MESSAGE = 0x03;      //!< MPEG-2 DSM-CC Download Message
+        static constexpr uint16_t DSMCC_MESSAGE_ID_DII = 0x1002;           //!< DownloadInfoIndication
+        static constexpr uint16_t DSMCC_MESSAGE_ID_DSI = 0x1006;           //!< DownloadServerInitiate
+        static constexpr uint32_t DSMCC_TAG_LITE_OPTIONS = 0x49534F05;     //!< TAG_LITE_OPTIONS (Lite Options Profile Body)
+        static constexpr uint32_t DSMCC_TAG_BIOP_PROFILE = 0x49534F06;     //!< TAG_BIOP (BIOP Profile Body)
+        static constexpr uint32_t DSMCC_TAG_CONN_BINDER = 0x49534F40;      //!< TAG_ConnBinder (DSM::ConnBinder)
+        static constexpr uint32_t DSMCC_TAG_OBJECT_LOCATION = 0x49534F50;  //!< TAG_ObjectLocation (BIOP::ObjectLocation)
     };
 }  // namespace ts

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------------
 //
 // TSDuck - The MPEG Transport Stream Toolkit
-// Copyright (c) 2024, Piotr Serafin
+// Copyright (c) 2025, Piotr Serafin
 // BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
 //
 //----------------------------------------------------------------------------

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
@@ -59,7 +59,7 @@ namespace ts {
             Tap tap {};
 
             // UnknownComponent
-            ByteBlock component_data {};
+            std::optional<ByteBlock> component_data {};
         };
 
         class TSDUCKDLL TaggedProfile {
@@ -72,7 +72,7 @@ namespace ts {
             std::list<LiteComponent> liteComponents {};
 
             // Any other profile for now
-            ByteBlock profile_data {};
+            std::optional<ByteBlock> profile_data {};
         };
 
         class TSDUCKDLL IOR {
@@ -128,14 +128,16 @@ namespace ts {
 
         // Inherited methods
         DeclareDisplaySection();
+        virtual bool     isPrivate() const override;
         virtual uint16_t tableIdExtension() const override;
 
     protected:
         // Inherited methods
-        virtual void clearContent() override;
-        virtual void serializePayload(BinaryTable&, PSIBuffer&) const override;
-        virtual void deserializePayload(PSIBuffer&, const Section&) override;
-        virtual void buildXML(DuckContext&, xml::Element*) const override;
-        virtual bool analyzeXML(DuckContext& duck, const xml::Element* element) override;
+        virtual void   clearContent() override;
+        virtual size_t maxPayloadSize() const override;
+        virtual void   serializePayload(BinaryTable&, PSIBuffer&) const override;
+        virtual void   deserializePayload(PSIBuffer&, const Section&) override;
+        virtual void   buildXML(DuckContext&, xml::Element*) const override;
+        virtual bool   analyzeXML(DuckContext& duck, const xml::Element* element) override;
     };
 }  // namespace ts

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
@@ -23,6 +23,10 @@ namespace ts {
     //!
     class TSDUCKDLL DSMCCUserToNetworkMessage: public AbstractLongTable {
     public:
+        //!
+        //! Representation of DSM-CC Message Header structure
+        //! @see ETSI TR 101 202 V1.2.1 (2003-01), A.1
+        //!
         class TSDUCKDLL MessageHeader {
             TS_DEFAULT_COPY_MOVE(MessageHeader);
 
@@ -44,87 +48,116 @@ namespace ts {
             void clear();
         };
 
+        //!
+        //! Representation of Tap structure
+        //! @see ETSI TR 101 202 V1.2.1 (2003-01), 4.7.2.5
+        //!
         class TSDUCKDLL Tap {
         public:
-            Tap() = default;        //!< Default constructor.
-            uint16_t id = 0x0000;   //!< Tap Id
-            uint16_t use = 0x0016;  //!<
-            uint16_t association_tag = 0x0000;
-            uint16_t selector_type = 0x0001;
-            uint32_t transaction_id = 0;
-            uint32_t timeout = 0;
+            Tap() = default;                    //!< Default constructor.
+            uint16_t id = 0x0000;               //!< This field is for private use (shall be set to zero if not used).
+            uint16_t use = 0x0016;              //!< Field indicating the usage of the Tap.
+            uint16_t association_tag = 0x0000;  //!< Field to associate the Tap with a particular (Elementary) Stream.
+            uint16_t selector_type = 0x0001;    //!< Optional selector, to select the associated data from the associated (Elementary) Stream.
+            uint32_t transaction_id = 0;        //!< Used for session integrity and error processing.
+            uint32_t timeout = 0;               //!< Defined in units of µs, specific to the construction of a particular carousel.
         };
 
-        //  ******************************
-        //  *** DownloadServerInitiate ***
-        //  ******************************
+        //  *****************************************
+        //  *** DownloadServerInitiate Structures ***
+        //  *****************************************
+
+        //!
+        //! Representation of LiteComponent structure (BIOP::Object Location, DSM::ConnBinder)
+        //! @see ETSI TR 101 202 V1.2.1 (2003-01), Table 4.5
+        //!
         class TSDUCKDLL LiteComponent {
         public:
-            LiteComponent() = default;  //!< Default constructor.
-            uint32_t component_id_tag = 0;
+            LiteComponent() = default;      //!< Default constructor.
+            uint32_t component_id_tag = 0;  //!< Component idenfitier tag (eg. TAG_ObjectLocation, TAG_ConnBinder).
 
-            // BIOPObjectLocation
-            uint32_t  carousel_id = 0;
-            uint16_t  module_id = 0;
-            uint8_t   version_major = 0x01;
-            uint8_t   version_minor = 0x00;
-            ByteBlock object_key_data {};
+            // BIOPObjectLocation context
+            uint32_t  carousel_id = 0;       //!< The carouselId field provides a context for the moduleId field.
+            uint16_t  module_id = 0;         //!< Identifies the module in which the object is conveyed within the carousel.
+            uint8_t   version_major = 0x01;  //!< Fixed, BIOP protocol major version 1.
+            uint8_t   version_minor = 0x00;  //!< Fixed, BIOP protocol minor version 0.
+            ByteBlock object_key_data {};    //!< Identifies the object within the module in which it is broadcast.
 
-            // DSMConnBinder
-            Tap tap {};
+            // DSMConnBinder context
+            Tap tap {};  //!< Tap structure
 
-            // UnknownComponent
-            std::optional<ByteBlock> component_data {};
+            // UnknownComponent context
+            std::optional<ByteBlock> component_data {};  //!< Optional component data, for UnknownComponent.
         };
 
+        //!
+        //! Representation of TaggedProfile structure (BIOP Profile Body, Lite Options Profile Body)
+        //! @see ETSI TR 101 202 V1.2.1 (2003-01), 4.7.3.2, 4.7.3.3
+        //!
         class TSDUCKDLL TaggedProfile {
         public:
-            TaggedProfile() = default;  //!< Default constructor.
-            uint32_t profile_id_tag = 0;
-            uint8_t  profile_data_byte_order = 0;
+            TaggedProfile() = default;             //!< Default constructor.
+            uint32_t profile_id_tag = 0;           //!< Profile identifier tag (eg. TAG_BIOP, TAG_LITE_OPTIONS).
+            uint8_t  profile_data_byte_order = 0;  //!< Fixed 0x00, big endian byte order.
 
-            // BIOP Profile Body
-            std::list<LiteComponent> liteComponents {};
+            // BIOP Profile Body context
+            std::list<LiteComponent> liteComponents {};  //!< List of LiteComponent.
 
-            // Any other profile for now
-            std::optional<ByteBlock> profile_data {};
+            // Any other profile context for now
+            std::optional<ByteBlock> profile_data {};  //!< Optional profile data, for UnknownProfile.
         };
 
+        //!
+        //! Representation of Interoperable Object Reference (IOR) structure
+        //! @see ETSI TR 101 202 V1.2.1 (2003-01), 4.7.3.1
+        //!
         class TSDUCKDLL IOR {
         public:
-            IOR() = default;  //!< Default constructor.
-            ByteBlock                type_id {};
-            std::list<TaggedProfile> tagged_profiles {};
+            IOR() = default;                              //!< Default constructor.
+            ByteBlock                type_id {};          //!< U-U Objects type_id.
+            std::list<TaggedProfile> tagged_profiles {};  //!< List of tagged profiles.
         };
 
-        //  ******************************
-        //  *** DownloadInfoIndication ***
-        //  ******************************
+        //  *****************************************
+        //  *** DownloadInfoIndication Structures ***
+        //  *****************************************
+
+        //!
+        //! Representation of BIOP::ModuleInfo structure
+        //! @see ETSI TR 101 202 V1.2.1 (2003-01), Table 4.14
+        //!
         class TSDUCKDLL Module: public EntryWithDescriptors {
             TS_NO_DEFAULT_CONSTRUCTORS(Module);
             TS_DEFAULT_ASSIGMENTS(Module);
 
         public:
-            uint16_t       module_id = 0;
-            uint32_t       module_size = 0;
-            uint8_t        module_version = 0;
-            uint32_t       module_timeout = 0;
-            uint32_t       block_timeout = 0;
-            uint32_t       min_block_time = 0;
-            std::list<Tap> taps {};
-
+            uint16_t       module_id = 0;       //!< Identifies the module.
+            uint32_t       module_size = 0;     //!< Length of the module in bytes.
+            uint8_t        module_version = 0;  //!< Identifies the version of the module.
+            uint32_t       module_timeout = 0;  //!< Time out value in microseconds that may be used to time out the acquisition of all Blocks of the Module.
+            uint32_t       block_timeout = 0;   //!< Time out value in microseconds that may be used to time out the reception of the next Block after a Block has been acquired.
+            uint32_t       min_block_time = 0;  //!< Indicates the minimum time period that exists between the delivery of two subsequent Blocks of the Module.
+            std::list<Tap> taps {};             //!< List of Taps.
+                                                //
+            //!
+            //! Constructor.
+            //! @param [in] table Parent DSMCCUserToNetworkMessage Table.
+            //!
             explicit Module(const AbstractTable* table);
         };
 
-        MessageHeader header {};
-        ByteBlock     server_id {};  //!< Conveys the data of the block.
-        IOR           ior {};
+        MessageHeader header {};     //!< DSM-CC Message Header.
+        ByteBlock     server_id {};  //!< Field shall be set to 20 bytes with the value 0xFF.
+        IOR           ior {};        //!< Interoperable Object Reference (IOR) structure.
 
+        //!
+        //! List of Modules
+        //!
         using ModuleList = EntryWithDescriptorsList<Module>;
 
-        uint32_t   download_id = 0;
-        uint16_t   block_size = 0;
-        ModuleList modules;
+        uint32_t   download_id = 0;  //!< Same value as the downloadId field of the DownloadDataBlock() messages which carry the Blocks of the Module.
+        uint16_t   block_size = 0;   //!< Block size of all the DownloadDataBlock() messages which convey the Blocks of the Modules.
+        ModuleList modules;          //!< List of modules structures.
 
         //!
         //! Default constructor.
@@ -155,16 +188,16 @@ namespace ts {
         virtual bool   analyzeXML(DuckContext& duck, const xml::Element* element) override;
 
     private:
-        static constexpr size_t MESSAGE_HEADER_SIZE = 12;  //!< DSM-CC Message Header size w/o adaptation header
+        static constexpr size_t MESSAGE_HEADER_SIZE = 12;  //!< DSM-CC Message Header size w/o adaptation header.
         static constexpr size_t SERVER_ID_SIZE = 20;       //!< Fixed size in bytes of server_id.
 
-        static constexpr uint8_t  DSMCC_PROTOCOL_DISCRIMINATOR = 0x11;     //!< Protocol Discriminator for DSM-CC
-        static constexpr uint8_t  DSMCC_TYPE_DOWNLOAD_MESSAGE = 0x03;      //!< MPEG-2 DSM-CC Download Message
-        static constexpr uint16_t DSMCC_MESSAGE_ID_DII = 0x1002;           //!< DownloadInfoIndication
-        static constexpr uint16_t DSMCC_MESSAGE_ID_DSI = 0x1006;           //!< DownloadServerInitiate
-        static constexpr uint32_t DSMCC_TAG_LITE_OPTIONS = 0x49534F05;     //!< TAG_LITE_OPTIONS (Lite Options Profile Body)
-        static constexpr uint32_t DSMCC_TAG_BIOP_PROFILE = 0x49534F06;     //!< TAG_BIOP (BIOP Profile Body)
-        static constexpr uint32_t DSMCC_TAG_CONN_BINDER = 0x49534F40;      //!< TAG_ConnBinder (DSM::ConnBinder)
-        static constexpr uint32_t DSMCC_TAG_OBJECT_LOCATION = 0x49534F50;  //!< TAG_ObjectLocation (BIOP::ObjectLocation)
+        static constexpr uint8_t  DSMCC_PROTOCOL_DISCRIMINATOR = 0x11;     //!< Protocol Discriminator for DSM-CC.
+        static constexpr uint8_t  DSMCC_TYPE_DOWNLOAD_MESSAGE = 0x03;      //!< MPEG-2 DSM-CC Download Message.
+        static constexpr uint16_t DSMCC_MESSAGE_ID_DII = 0x1002;           //!< DownloadInfoIndication.
+        static constexpr uint16_t DSMCC_MESSAGE_ID_DSI = 0x1006;           //!< DownloadServerInitiate.
+        static constexpr uint32_t DSMCC_TAG_LITE_OPTIONS = 0x49534F05;     //!< TAG_LITE_OPTIONS (Lite Options Profile Body).
+        static constexpr uint32_t DSMCC_TAG_BIOP_PROFILE = 0x49534F06;     //!< TAG_BIOP (BIOP Profile Body).
+        static constexpr uint32_t DSMCC_TAG_CONN_BINDER = 0x49534F40;      //!< TAG_ConnBinder (DSM::ConnBinder).
+        static constexpr uint32_t DSMCC_TAG_OBJECT_LOCATION = 0x49534F50;  //!< TAG_ObjectLocation (BIOP::ObjectLocation).
     };
 }  // namespace ts

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.names
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.names
@@ -3,4 +3,60 @@ Inherit = DSMCC_download_data_message.dsmcc_type
 [DSMCC_user_to_network_message.message_id]
 # Valid only for dsmcc_type = 0x03 (Download message)
 Inherit = DSMCC_download_data_message.message_id
-
+[DSMCC_user_to_network_message.magic]
+Bits=32
+0x42494F50 = BIOP
+[DSMCC_user_to_network_message.type_id]
+Bits=32
+0x64697200 = DSM::Directory (dir)
+0x66696c00 = DSM::File (fil)
+0x73726700 = DSM::ServiceGateway (srg)
+0x73746500 = DSM::StreamEvent (ste)
+0x73747200 = DSM::StreamEventMessage (str)
+[DSMCC_user_to_network_message.tag]
+Bits=32
+0x49534f00 = TAG_MIN
+0x49534f01 = TAG_CHILD
+0x49534f02 = TAG_OPTIONS
+0x49534f03 = TAG_LITE_MIN
+0x49534f04 = TAG_LITE_CHILD
+0x49534f05 = TAG_LITE_OPTIONS (Lite Options Profile Body)
+0x49534F06 = TAG_BIOP (BIOP Profile Body)
+0x49534f07 = TAG_ONC
+0x49534F40 = TAG_ConnBinder (DSM::ConnBinder)
+0x49534f41 = TAG_IIOPAddr
+0x49534f42 = TAG_Addr
+0x49534f43 = TAG_NameId
+0x49534f44 = TAG_IntfCode
+0x49534f45 = TAG_ObjectKey
+0x49534f46 = TAG_ServiceLocation (DSM::ServiceLocation)
+0x49534F50 = TAG_ObjectLocation (BIOP::ObjectLocation)
+0x49534f58 = TAG_Intf
+[DSMCC_user_to_network_message.tap_use]
+Bits=16
+0x0000 = UNKNOWN
+0x0001 = MPEG_TS_UP_USE
+0x0002 = MPEG_TS_DOWN_USE
+0x0003 = MPEG_ES_UP_USE
+0x0004 = MPEG_ES_DOWN_USE
+0x0005 = DOWNLOAD_CTRL_USE
+0x0006 = DOWNLOAD_CTRL_UP_USE
+0x0007 = DOWNLOAD_CTRL_DOWN_USE
+0x0008 = DOWNLOAD_DATA_USE
+0x0009 = DOWNLOAD_DATA_UP_USE
+0x000A = DOWNLOAD_DATA_DOWN_USE
+0x000B = STR_NPT_USE (Stream NPT Descriptors)
+0x000C = STR_STATUS_AND_EVENT_USE (Both Stream Mode and Stream Event Descriptors)
+0x000D = STR_EVENT_USE (Stream Event Descriptors)
+0x000E = STR_STATUS_USE (Stream Mode Descriptors)
+0x000F = RPC_USE
+0x0010 = IP_USE
+0x0011 = SDB_CTRL_USE
+0x0015 = T120_TAP reserved
+0x0016 = BIOP_DELIVERY_PARA_USE (Module delivery parameters)
+0x0017 = BIOP_OBJECT_USE (BIOP objects in Modules)
+0x0018 = BIOP_ES_USE (Elementary Stream (Video/Audio))
+0x0019 = BIOP_PROGRAM_USE (Program (DVB Service) Reference)
+0x001A = BIOP_DNL_CTRL_USE
+0x8000 = STR_DVBTIMEL_USE (DVB broadcast_timeline_descriptor)
+0x8001 = STR_DVBEVENT_USE (DVB synchronised_event_descriptor)

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.names
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.names
@@ -1,0 +1,6 @@
+[DSMCC_user_to_network_message.dsmcc_type]
+Inherit = DSMCC_download_data_message.dsmcc_type
+[DSMCC_user_to_network_message.message_id]
+# Valid only for dsmcc_type = 0x03 (Download message)
+Inherit = DSMCC_download_data_message.message_id
+

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.xml
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.xml
@@ -20,48 +20,55 @@
             Hexadecimal content
           </type_id>
           <tagged_profile profile_id_tag="uint32_t, required" profile_data_byte_order="uint8, required">
-            <BIOP_profile_body lite_components_count="uint8_t,required">
-              <BIOP_object_location
-                component_id_tag="uint32_t, required"
-                carousel_id="uint32_t, required"
-                module_id="uint16_t, required"
-                version_major="uint8_t, required"
-                version_minfor="uint8_t, required">
-                <object_key_data>
-                    Hexadecimal content
-                </object_key_data>
-              </BIOP_object_location>
-              <DSM_conn_binder
-                component_id_tag="uint32_t, required">
-                <BIOP_tap
-                  id="uint16, required"
-                  use="uint16, required"
-                  association_tag="uint16, required"
-                  selector_type="uint16, required"
-                  transaction_id="uint32, required"
-                  timeout="uint32, required"/>
-              </DSM_conn_binder>
-              <Unknown_component
-                component_id_tag="uint32_t, required">
-                <component_data>
-                    Hexadecimal content
-                </component_data>
-              </Unknown_component>
+            <!-- profile_id_tag = 0x49534F06 -->
+            <BIOP_profile_body>
+              <lite_component component_id_tag="uint32_t, required">
+                <!-- component_id_tag = 0x49534F50 (TAG_ObjectLocation) -->
+                <BIOP_object_location
+                  carousel_id="uint32_t, required"
+                  module_id="uint16_t, required"
+                  version_major="uint8_t, required"
+                  version_minor="uint8_t, required">
+                  <object_key_data>
+                      Hexadecimal content
+                  </object_key_data>
+                </BIOP_object_location>
+                <!-- component_id_tag = 0x49534F40 (TAG_ConnBinder) -->
+                <DSM_conn_binder>
+                  <BIOP_tap
+                    id="uint16, required"
+                    use="uint16, required"
+                    association_tag="uint16, required"
+                    selector_type="uint16, required"
+                    transaction_id="uint32, required"
+                    timeout="uint32, required"/>
+                </DSM_conn_binder>
+                <!-- component_id_tag = other (Unknown) -->
+                <Unknown_component>
+                  <component_data>
+                      Hexadecimal content
+                  </component_data>
+                </Unknown_component>
+              </lite_component>
             </BIOP_profile_body>
-            <profile_data>
-            Hexadecimal content
-            </profile_data>
-         </tagged_profile>
+            <!-- profile_id_tag = 0x49534F05 -->
+            <Lite_options_profile_body>
+              <profile_data>
+              Hexadecimal content
+              </profile_data>
+            </Lite_options_profile_body>
+            <!-- profile_id_tag = other -->
+            <Unknown_profile_body>
+              <profile_data>
+              Hexadecimal content
+              </profile_data>
+            </Unknown_profile_body>
+          </tagged_profile>
         </IOR>
-        <private_data>
-          Hexadecimal content
-        </private_data>
       </DSI>
       <DII
         download_id="uint32, required"
-        block_size="uint16, required"
-        number_of_modules="uint16, required">
-        <!-- One per module -->
+        block_size="uint16, required">
         <module
           module_id="uint16, required"
           module_size="uint32, required"
@@ -69,12 +76,10 @@
           module_timeout="uint32, required"
           block_timeout="uint32, required"
           min_block_time="uint32, required">
-          <!-- One per tap -->
           <tap
             id="uint16, required"
             use="uint16, required"
-            association_tag="uint16, required"
-            selector_type="uint16, required"/>
+            association_tag="uint16, required"/>
           <_any in="_descriptors"/>
         </module>
       </DII>

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.xml
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_tables>
+
+    <DSMCC_user_to_network_message
+        version="uint5, default=0"
+        current="bool, default=true"
+        table_id_extension="uint16, default=0xFFFF"
+        protocol_discriminator="uint8, required, default=0x11"
+        dsmcc_type="uint8, required, default=0x03"
+        message_id="uint16, required"
+        transaction_id="uint32, required">
+      <_any in="_metadata"/>
+      <DSI>
+        <server_id>
+          Hexadecimal content
+        </server_id>
+        <private_data>
+          Hexadecimal content
+        </private_data>
+      </DSI>
+      <DII
+        download_id="uint32, required"
+        block_size="uint16, required"
+        number_of_modules="uint16, required">
+        <!-- One per module -->
+        <module
+          module_id="uint16, required"
+          module_size="uint32, required"
+          module_version="uint8, required">
+          <module_info>
+            Hexadecimal content
+          </module_info>
+        </module>
+        <dii_private_data>
+          Hexadecimal content
+        </dii_private_data>
+      </DII>
+    </DSMCC_user_to_network_message>
+
+  </_tables>
+</tsduck>

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.xml
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.xml
@@ -27,14 +27,18 @@
         <module
           module_id="uint16, required"
           module_size="uint32, required"
-          module_version="uint8, required">
-          <module_info>
-            Hexadecimal content
-          </module_info>
+          module_version="uint8, required"
+          module_timeout="uint32, required"
+          block_timeout="uint32, required"
+          min_block_time="uint32, required">
+          <!-- One per tap -->
+          <tap
+            id="uint16, required"
+            use="uint16, required"
+            association_tag="uint16, required"
+            selector_type="uint16, required"/>
+          <_any in="_descriptors"/>
         </module>
-        <dii_private_data>
-          Hexadecimal content
-        </dii_private_data>
       </DII>
     </DSMCC_user_to_network_message>
 

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.xml
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.xml
@@ -15,6 +15,44 @@
         <server_id>
           Hexadecimal content
         </server_id>
+        <IOR>
+          <type_id>
+            Hexadecimal content
+          </type_id>
+          <tagged_profile profile_id_tag="uint32_t, required" profile_data_byte_order="uint8, required">
+            <BIOP_profile_body lite_components_count="uint8_t,required">
+              <BIOP_object_location
+                component_id_tag="uint32_t, required"
+                carousel_id="uint32_t, required"
+                module_id="uint16_t, required"
+                version_major="uint8_t, required"
+                version_minfor="uint8_t, required">
+                <object_key_data>
+                    Hexadecimal content
+                </object_key_data>
+              </BIOP_object_location>
+              <DSM_conn_binder
+                component_id_tag="uint32_t, required">
+                <BIOP_tap
+                  id="uint16, required"
+                  use="uint16, required"
+                  association_tag="uint16, required"
+                  selector_type="uint16, required"
+                  transaction_id="uint32, required"
+                  timeout="uint32, required"/>
+              </DSM_conn_binder>
+              <Unknown_component
+                component_id_tag="uint32_t, required">
+                <component_data>
+                    Hexadecimal content
+                </component_data>
+              </Unknown_component>
+            </BIOP_profile_body>
+            <profile_data>
+            Hexadecimal content
+            </profile_data>
+         </tagged_profile>
+        </IOR>
         <private_data>
           Hexadecimal content
         </private_data>


### PR DESCRIPTION
#### Related issue (if any):
#82

#### Brief description of the proposed changes:
This change introduces new tables & descriptors. 

#### Tables
- DSM-CC User-to-Network Message (TID: 0x3B) with support for both DownloadServerInitiate (DSI) and DownloadInfoIndication (DII) schemas
- DSM-CC Download Data Message (TID: 0x3C)

#### Descriptors
Added DSM-CC U-N Message Specific Descriptors Test

- type_descriptor (0x01)
- name_descriptor (0x02)
- info_descriptor (0x03)
- module_link_descriptor (0x04)
- CRC32_descriptor (0x05)
- location_descriptor (0x06)
- est_download_time_descriptor (0x07)
- group_link_descriptor (0x08)
- compressed_module_descriptor (0x09)
- SSU_module_type_descriptor (0x0A)
- subgroup_association_descriptor (0x0B)
- label_descriptor (0x70)
- caching_priority_descriptor (0x71)

