### PR TITLE
both start and end times are needed to define the viewing window

### DIFF
--- a/src/libtscore/tsVersion.h
+++ b/src/libtscore/tsVersion.h
@@ -26,4 +26,4 @@
 //! TSDuck commit number (automatically updated by Git hooks).
 //! @ingroup app
 //!
-#define TS_COMMIT 4156
+#define TS_COMMIT 4157

--- a/src/libtsduck/dtv/descriptors/dvb/tsCPCMDeliverySignallingDescriptor.cpp
+++ b/src/libtsduck/dtv/descriptors/dvb/tsCPCMDeliverySignallingDescriptor.cpp
@@ -78,7 +78,7 @@ void ts::CPCMDeliverySignallingDescriptor::CPCMv1Signalling::serializePayload(PS
     buf.putBits(copy_control, 3);
     buf.putBit(do_not_cpcm_scramble);
     buf.putBit(viewable);
-    buf.putBit(view_window_start.has_value() || view_window_end.has_value());
+    buf.putBit(view_window_start.has_value() && view_window_end.has_value());
     buf.putBit(view_period_from_first_playback.has_value());
     buf.putBit(simultaneous_view_count.has_value());
     buf.putBit(move_local);
@@ -95,7 +95,7 @@ void ts::CPCMDeliverySignallingDescriptor::CPCMv1Signalling::serializePayload(PS
     buf.putBit(disable_analogue_hd_export);
     buf.putBit(disable_analogue_hd_consumption);
     buf.putBit(image_constraint);
-    if (view_window_start.has_value() || view_window_end.has_value()) {
+    if (view_window_start.has_value() && view_window_end.has_value()) {
         buf.putMJD(view_window_start.value(), MJD_FULL);
         buf.putMJD(view_window_end.value(), MJD_FULL);
     }
@@ -362,6 +362,10 @@ bool ts::CPCMDeliverySignallingDescriptor::analyzeXML(DuckContext& duck, const x
             if (ok && children[i]->hasAttribute(u"view_window_end")) {
                 ok = children[i]->getDateTimeAttribute(tmpDate, u"view_window_end", true);
                 cpcm_v1_delivery_signalling.view_window_end = tmpDate;
+            }
+            if (ok && (children[i]->hasAttribute(u"view_window_start") + children[i]->hasAttribute(u"view_window_end") == 1)) {
+                element->report().error(u"both 'view_window_start' and 'view_window_end' must be specified or omitted in <%s>", element->name());
+                ok = false;
             }
             if (ok && children[i]->hasAttribute(u"remote_access_date")) {
                 ok = children[i]->getDateTimeAttribute(tmpDate, u"remote_access_date", true);


### PR DESCRIPTION
Ensure that both the window_start and window_end times are specified. 

See clause 5.4.5 of ETSI TS 102 825-4

