### PR TITLE
add support for AVS2 video tracks - in MPEG TS only

### DIFF
--- a/src/libtsduck/dtv/codec/tsCodecType.cpp
+++ b/src/libtsduck/dtv/codec/tsCodecType.cpp
@@ -42,6 +42,7 @@ const ts::Names& ts::CodecTypeEnum()
         {u"DTS-HD",        CodecType::DTSHD},
         {u"Teletext",      CodecType::TELETEXT},
         {u"DVB Subtitles", CodecType::DVB_SUBTITLES},
+        {u"AVS2 Video",    CodecType::AVS2_VIDEO},
         {u"AVS3 Video",    CodecType::AVS3_VIDEO},
         {u"AVS2 Audio",    CodecType::AVS2_AUDIO},
         {u"AVS3 Audio",    CodecType::AVS3_AUDIO},
@@ -86,6 +87,7 @@ const ts::Names& ts::CodecTypeArgEnum()
         {u"DTSHD",         CodecType::DTSHD},
         {u"Teletext",      CodecType::TELETEXT},
         {u"DVBSubtitles",  CodecType::DVB_SUBTITLES},
+        {u"AVS2Video",     CodecType::AVS2_VIDEO},
         {u"AVS3Video",     CodecType::AVS3_VIDEO},
         {u"AVS2Audio",     CodecType::AVS2_AUDIO},
         {u"AVS3Audio",     CodecType::AVS3_AUDIO},
@@ -134,6 +136,7 @@ bool ts::CodecTypeIsVideo(CodecType ct)
         CodecType::LCEVC,
         CodecType::VP9,
         CodecType::AV1,
+        CodecType::AVS2_VIDEO,
         CodecType::AVS3_VIDEO,
     };
 

--- a/src/libtsduck/dtv/codec/tsCodecType.h
+++ b/src/libtsduck/dtv/codec/tsCodecType.h
@@ -53,7 +53,8 @@ namespace ts {
         DTSHD,         //!< HD Digital Theater Systems audio, aka DTS++.
         TELETEXT,      //!< Teletext pages or subtitles, ETSI EN 300 706.
         DVB_SUBTITLES, //!< DVB subtitles, ETSI EN 300 743.
-        AVS3_VIDEO,    //!< AVS3 video (AVS is Audio Video Standards workgroup of China).
+        AVS2_VIDEO,     //!< AVS2 video (AVS is Audio Video Standards workgroup of China).
+        AVS3_VIDEO,     //!< AVS3 video (AVS is Audio Video Standards workgroup of China).
         AVS2_AUDIO,    //!< AVS2 audio (AVS is Audio Video Standards workgroup of China).
         AVS3_AUDIO,    //!< AVS3 audio (AVS is Audio Video Standards workgroup of China).
     };

--- a/src/libtsduck/dtv/signalization/tsStreamType.cpp
+++ b/src/libtsduck/dtv/signalization/tsStreamType.cpp
@@ -56,6 +56,7 @@ bool ts::StreamTypeIsVideo(uint8_t st)
            st == ST_JPEG_XS_VIDEO ||
            st == ST_EVC_VIDEO     ||
            st == ST_LCEVC_VIDEO   ||
+           st == ST_AVS2_VIDEO    ||
            st == ST_AVS3_VIDEO;
 }
 

--- a/src/libtsduck/dtv/signalization/tsStreamType.h
+++ b/src/libtsduck/dtv/signalization/tsStreamType.h
@@ -112,6 +112,7 @@ namespace ts {
 
         // Valid after an appropriate AVS registration descriptor.
 
+        ST_AVS2_VIDEO       = 0xD2, //!< AVS2 video
         ST_AVS2_AUDIO       = 0xD3, //!< AVS2 audio
         ST_AVS3_VIDEO       = 0xD4, //!< AVS3 video
         ST_AVS3_AUDIO       = 0xD5, //!< AVS3 audio

--- a/src/libtsduck/dtv/signalization/tsStreamType.names
+++ b/src/libtsduck/dtv/signalization/tsStreamType.names
@@ -105,6 +105,8 @@ Extended = true
 0x48444D56_A1 = HDMV AC-3+ Secondary Audio
 0x48444D56_A2 = DTS-HD Secondary Audio
 # These could be used in the context of an appropriate AVS registration id, but these values are currently unused in the industry
+0xD2 = AVS2 video
+0x41565356_D2 = AVS2 video
 0xD3 = AVS2 audio
 0x41565341_D3 = AVS2 audio
 0xD4 = AVS3 video


### PR DESCRIPTION
Add the supporting stream type (0xD2) for AVS2 coded video in an MPEG transport stream.

Samples are available at https://github.com/xatabhk/avs2-avs3-video-samples., although the `registration_descriptor` for AVSV should be in the outer (PMT) descriptor loop rather than the inner (ES) descriptor loop (see [北京冬奧片花_Beijing 2022 winter olympics emblem_640x360_avs2.ts](https://github.com/xatabhk/avs2-avs3-video-samples/raw/refs/heads/master/TS/%E5%8C%97%E4%BA%AC%E5%86%AC%E5%A5%A7%E7%89%87%E8%8A%B1_Beijing%202022%20winter%20olympics%20emblem_640x360_avs2.ts)
