### PR TITLE
use standard way to widen strings in macros

### DIFF
--- a/src/libtscore/system/windows/tsWinUtils.cpp
+++ b/src/libtscore/system/windows/tsWinUtils.cpp
@@ -411,7 +411,7 @@ ts::UString ts::NameGUID(const ::GUID& guid)
         const UChar*   name;
     };
     static const KnownValue knownValues[] = {
-#define _N_(g) {&g, u#g},
+#define _N_(g) {&g, TS_USTRINGIFY1(g)},
         _N_(AM_INTERFACESETID_Standard)
         _N_(AM_KSCATEGORY_AUDIO)
         _N_(AM_KSCATEGORY_CAPTURE)


### PR DESCRIPTION
MSVC may be OK with the current code, but Clang is not. There is a macro to help with that.