### PR TITLE
fix __in usage if it's not defined

### DIFF
--- a/src/libtscore/system/tsUserInterrupt.h
+++ b/src/libtscore/system/tsUserInterrupt.h
@@ -91,6 +91,9 @@ namespace ts {
     private:
 #if defined(TS_WINDOWS)
 
+#ifndef __in
+    #define __in
+#endif
         static ::BOOL WINAPI sysHandler(__in ::DWORD dwCtrlType);
 
 #elif defined(TS_UNIX)


### PR DESCRIPTION
It's not defined by default when including Windows headers in mingw-w64.