### PR TITLE
SharedLibrary: silence error in function pointer case in LLVM

### DIFF
--- a/src/libtscore/system/tsSharedLibrary.cpp
+++ b/src/libtscore/system/tsSharedLibrary.cpp
@@ -119,7 +119,7 @@ void* ts::SharedLibrary::getSymbol(const std::string& name) const
 #if defined(TSDUCK_STATIC)
         // Nothing to do, load() previously failed.
 #elif defined(TS_WINDOWS)
-        result = ::GetProcAddress(_module, name.c_str());
+        result = (void*)::GetProcAddress(_module, name.c_str());
 #else
         result = ::dlsym(_dl, name.c_str());
 #endif


### PR DESCRIPTION
A recent LLVM complains when casting function pointers.

> base/system/tsSharedLibrary.cpp:122:18: error: assigning to 'void *' from 'FARPROC' (aka 'long long (*)()') converts between void pointer and function pointer

`static_cast` doesn't work so we use a C-style cast. The `getSymbol()` method is not used anyway.
