### PR TITLE
use lowercase Windows headers

### DIFF
--- a/src/libtscore/crypto/tsSystemRandomGenerator.h
+++ b/src/libtscore/crypto/tsSystemRandomGenerator.h
@@ -17,7 +17,7 @@
 
 #if defined(TS_WINDOWS)
     #include "tsBeforeStandardHeaders.h"
-    #include <Wincrypt.h>
+    #include <wincrypt.h>
     #include "tsAfterStandardHeaders.h"
 #endif
 

--- a/src/libtscore/network/windows/tsWebRequestGuts.cpp
+++ b/src/libtscore/network/windows/tsWebRequestGuts.cpp
@@ -27,7 +27,7 @@
 #include "tsWinUtils.h"
 
 #include "tsBeforeStandardHeaders.h"
-#include <WinInet.h>
+#include <wininet.h>
 #include "tsAfterStandardHeaders.h"
 
 // Required link libraries.

--- a/src/libtscore/system/tsFileUtils.cpp
+++ b/src/libtscore/system/tsFileUtils.cpp
@@ -20,7 +20,7 @@
     #include <mmsystem.h>  // Memory management
     #include <psapi.h>     // Process API
     #include <comutil.h>   // COM utilities
-    #include <Shellapi.h>
+    #include <shellapi.h>
     #include "tsAfterStandardHeaders.h"
 #else
     #include "tsBeforeStandardHeaders.h"

--- a/src/libtscore/system/windows/tsComPtr.h
+++ b/src/libtscore/system/windows/tsComPtr.h
@@ -16,7 +16,7 @@
 #include "tsWinUtils.h"
 
 #include "tsBeforeStandardHeaders.h"
-#include <ObjIdl.h>
+#include <objidl.h>
 #include "tsAfterStandardHeaders.h"
 
 #if defined(DOXYGEN)

--- a/src/libtscore/system/windows/tsWinUtils.cpp
+++ b/src/libtscore/system/windows/tsWinUtils.cpp
@@ -17,7 +17,7 @@
 #include <errors.h>
 #include <shellapi.h>
 #include <setupapi.h>
-#include <WinInet.h>
+#include <wininet.h>
 #include <dshowasf.h>
 #include <ks.h>
 #include <ksproxy.h>

--- a/src/libtscore/system/windows/tsWinUtils.h
+++ b/src/libtscore/system/windows/tsWinUtils.h
@@ -18,7 +18,7 @@
 #include "tsComIds.h"
 
 #include "tsBeforeStandardHeaders.h"
-#include <ObjIdl.h>
+#include <objidl.h>
 #include "tsAfterStandardHeaders.h"
 
 namespace ts {


### PR DESCRIPTION
This is necessary to cross-compile on Linux with `mingw-w64`. `mingw-w64` use only lowercase for Windows headers. Using the Microsoft documented casing fails to build on file systems that are case sensitive. Using lowercase has the most compatibility among Windows build systems.