### PR TITLE
tsArgMix: fix cast error on Windows

### DIFF
--- a/src/libtscore/types/tsArgMix.cpp
+++ b/src/libtscore/types/tsArgMix.cpp
@@ -92,7 +92,7 @@ const char* ts::ArgMix::toCharPtr() const
                     return "";
                 }
                 else {
-                    return _value.path->c_str();
+                    return (const char*)_value.path->c_str();
                 }
             }
             else {


### PR DESCRIPTION
Compiling with LLVM gives this error

```
tsArgMix.cpp:95:28: error: cannot initialize return object of type 'const char *' with an rvalue of type 'const value_type *' (aka 'const wchar_t *')
[build]    95 |                     return _value.path->c_str();
[build]       |                            ^~~~~~~~~~~~~~~~~~~~
[build] 1 error generated.
```

The "if constexpr" will be false and will not use that code (`wchar_t` is used). But the code is compiled anyway and needs to compile properly. A C-style cast solve the issue of mismatched type. The cast is not a problem in the case this code is used since that's the actual return type of the method.