### PR TITLE
tsNames: avoid calling private methods in inline methods

### DIFF
--- a/src/libtscore/app/tsNames.cpp
+++ b/src/libtscore/app/tsNames.cpp
@@ -336,6 +336,11 @@ bool ts::Names::getValueImpl(uint_t& e, const UString& name, bool case_sensitive
     }
 }
 
+ts::NamesPtr ts::Names::GetSection(const UString& file_name, const UString& section_name, bool create)
+{
+    return AllInstances::Instance().get(section_name, file_name, create);
+}
+
 
 //----------------------------------------------------------------------------
 // Get the error message about a name failing to match a value.

--- a/src/libtscore/app/tsNames.h
+++ b/src/libtscore/app/tsNames.h
@@ -395,10 +395,7 @@ namespace ts {
         //! the section does not exist and @a create is false.
         //! @see MergeFile()
         //!
-        static NamesPtr GetSection(const UString& file_name, const UString& section_name, bool create)
-        {
-            return AllInstances::Instance().get(section_name, file_name, create);
-        }
+        static NamesPtr GetSection(const UString& file_name, const UString& section_name, bool create);
 
         //!
         //! Get the names from a bit-mask value.


### PR DESCRIPTION
The method may be inlined in parent classes, in external code. That results in needing to DLL export the private method so it can be called by the external code, even if it's not supposed to know about it.

Moving the inline code into a the C++ file ensures the call is never inlined by the caller, thus not needing to export `AllInstances::Instance().get()`.
