### PR TITLE
tsCommandLine: avoid calling private method in default destructor

### DIFF
--- a/src/libtscore/app/tsCommandLine.cpp
+++ b/src/libtscore/app/tsCommandLine.cpp
@@ -19,6 +19,9 @@ ts::CommandLine::CommandLine(Report& report) :
 {
 }
 
+ts::CommandLine::~CommandLine()
+{
+}
 
 //----------------------------------------------------------------------------
 // Set command line redirection from files.

--- a/src/libtscore/app/tsCommandLine.h
+++ b/src/libtscore/app/tsCommandLine.h
@@ -35,6 +35,11 @@ namespace ts {
         CommandLine(Report& report = CERR);
 
         //!
+        //! Destructor.
+        //!
+        virtual ~CommandLine();
+
+        //!
         //! Set the "shell" string for all commands.
         //! @param [in] shell Shell name string.
         //! @see Args::setShell()


### PR DESCRIPTION
The method may be inlined in parent classes, in external code. That results in needing to export the private `PredefinedCommands` destructor so it can be called by the external code, even if it's not supposed to know about it.

Moving the destructor to the C++ file ensures the default destructor call is not inline and thus accessing the private `PredefinedCommands` destructor which is not DLL exported.
