### PR TITLE
tsEditLine: fix unused warning with NOEDITLINE

### DIFF
--- a/src/libtscore/app/tsEditLine.cpp
+++ b/src/libtscore/app/tsEditLine.cpp
@@ -40,8 +40,10 @@ ts::EditLine::EditLine(const UString& prompt, const UString& next_prompt, const 
     _is_a_tty(StdInIsTerminal()),
     _prompt(prompt),
     _next_prompt(next_prompt),
-    _history_file(history_file),
-    _history_size(history_size)
+    _history_file(history_file)
+#if !defined(TS_NO_EDITLINE)
+    ,_history_size(history_size)
+#endif
 {
 #if !defined(TS_NO_EDITLINE)
     if (_is_a_tty) {

--- a/src/libtscore/app/tsEditLine.h
+++ b/src/libtscore/app/tsEditLine.h
@@ -113,12 +113,16 @@ namespace ts {
     private:
         bool    _is_a_tty = false;
         bool    _end_of_file = false;
+#if !defined(TS_NO_EDITLINE)
         bool    _update_history = false;
+#endif
         UString _prompt {};
         UString _next_prompt {};
         UString _previous_line {};
         UString _history_file {};
+#if !defined(TS_NO_EDITLINE)
         size_t  _history_size = 0;
+#endif
 
         static UString _default_prompt;
         static UString _default_next_prompt;


### PR DESCRIPTION
The unused warning will turn into a build error with -Werror