### PR TITLE
tsCOM: remove unused comsuppw library

### DIFF
--- a/src/libtscore/system/tsCOM.cpp
+++ b/src/libtscore/system/tsCOM.cpp
@@ -15,15 +15,6 @@
     #include "tsAfterStandardHeaders.h"
 #endif
 
-// Required link libraries under Windows.
-#if defined(TS_WINDOWS) && defined(TS_MSC)
-    #if defined(DEBUG)
-        #pragma comment(lib, "comsuppwd.lib") // COM utilities
-    #else
-        #pragma comment(lib, "comsuppw.lib")
-    #endif
-#endif
-
 // Constructor, initialize COM.
 ts::COM::COM(Report& report)
 {


### PR DESCRIPTION
It's not available in mingw-w64 and none of the helpers provided are used.