### PR TITLE
tsThread: don't call SetThreadDescription() is compiled for older Windows

### DIFF
--- a/src/libtscore/system/tsThread.cpp
+++ b/src/libtscore/system/tsThread.cpp
@@ -340,7 +340,7 @@ void ts::Thread::mainWrapper()
         ::pthread_setname_np(name.toUTF8().c_str());
 #elif defined(TS_FREEBSD) || defined(TS_DRAGONFLYBSD)
         ::pthread_setname_np(_pthread, name.toUTF8().c_str());
-#elif defined(TS_WINDOWS)
+#elif defined(TS_WINDOWS) && (NTDDI_VERSION >= NTDDI_WIN10_RS1)
         ::SetThreadDescription(::GetCurrentThread(), name.wc_str());
 #endif
     }


### PR DESCRIPTION
The documentation [^1] says the API is available since Windows 10 1607, aka Redstone 1. To support it regardless of the compilation flags it should be loaded dynamically.

[^1]: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription#requirements
