### PR TITLE
Detect Python alpha/beta/release candidate versions

### DIFF
--- a/scripts/make-config.sh
+++ b/scripts/make-config.sh
@@ -100,6 +100,7 @@ exist-wildcard () {
 extract-version() {
     "$1" --version 2>/dev/null |
         head -1 |
+        sed -E 's/(\.[0-9]*)(a|b|rc)[0-9]*/\1/' |
         sed -e 's/([^(]*)//g' |
         tr ' ' '\n' |
         grep '^[0-9][0-9]*\.[0-9\.]*$' |


### PR DESCRIPTION
According to https://peps.python.org/pep-0440/#public-version-identifiers, version suffixes can be "a", "b", "rc" with further "N" digits.

This applies to current Fedora Rawhide with "3.14.0b2", and fixes Python detection there.

Note: This requires sed to support the `-E` option for extended regex handling (for `a|b|rc`).

<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/download/docs/tsduck-dev.html#chap-contribution
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->
make-config.sh

#### Brief description of the proposed changes:
Introduce another `sed` expression to the version string filtering.

Note: This requires sed to support the "-E" option for extended regex handling (for "a|b|rc"). If this is not acceptable, a similar solution should or could be provided.
