### PR TITLE
Fix build failures with Python<3.9 due to (xml.etree.ElementTree.indent)

### DIFF
--- a/scripts/build-tables-model.py
+++ b/scripts/build-tables-model.py
@@ -47,7 +47,10 @@ if __name__ == '__main__':
     for topic in root:
         topic[:] = sorted(topic, key=lambda e: e.tag.lower() if isinstance(e.tag, str) else '')
     # Pretty print the XML file.
-    ET.indent(root)
+    if hasattr(ET, 'ident'):
+        ET.indent(root)
+    else:
+        print('Not pretty printing XML (not supported by Python<3.9)')
     # Generate the output file, remove empty lines.
     with open(sys.argv[1], 'w', encoding='utf-8') as output:
         print('<?xml version="1.0" encoding="UTF-8"?>', file=output)


### PR DESCRIPTION

#### Related issue (if any):
#1651 

#### Affected components:
Python build script: [build-tables-model.py](https://github.com/tsduck/tsduck/blob/master/scripts/build-tables-model.py)

#### Brief description of the proposed changes:

When building with Python versions <3.9 a build error occurs as the xml library within Python's standard library is missing xml.etree.ElementTree.indent feature.

I've proposed a fix here which checks if this feature exists and will generate the pretty print tree or print a warning message stating "Not pretty printing XML (not supported by Python<3.9)".