### PR TITLE
additional profile_idc values for VVC 

### DIFF
--- a/src/libtsduck/dtv/descriptors/mpeg/tsVVCVideoDescriptor.names
+++ b/src/libtsduck/dtv/descriptors/mpeg/tsVVCVideoDescriptor.names
@@ -1,11 +1,20 @@
 [VVC_video_descriptor.profile_idc]
 Bits = 7
 1  = Main 10
+2  = Main 12
+10 = Main 12 Intra
 17 = Multilayer Main 10
 33 = Main 10 4:4:4
+34 = Main 12 4:4:4
+35 = Main 16 4:4:4
+42 = Main 12 4:4:4 Intra
+43 = Main 16 4:4:4 Intra
 49 = Multilayer Main 10 4:4:4
 65 = Main 10 Still Picture
+66 = Main 12 Still Picture
 97 = Main 10 4:4:4 Still Picture
+98 = Main 12 4:4:4 Still Picture
+99 = Main 16 4:4:4 Still Picture
 
 [VVC_video_descriptor.tier]
 Bits = 1


### PR DESCRIPTION
#### Brief description of the proposed changes:
Add additional descriptive names for the `profile_idc` element in the MPEG defined `VVC_video_descriptor`.

These values can be found in Annex A of the latest VVC standard - [ITU-T H.266 (V3) (09/2023)](https://www.itu.int/rec/T-REC-H.266-202309-I).