### PR TITLE
Add sys/time.h header for macOS

### DIFF
--- a/src/libtscore/system/tsFileUtils.cpp
+++ b/src/libtscore/system/tsFileUtils.cpp
@@ -25,6 +25,7 @@
 #else
     #include "tsBeforeStandardHeaders.h"
     #include <sys/ioctl.h>
+    #include <sys/time.h>
     #include <sys/types.h>
     #include <sys/stat.h>
     #include <unistd.h>


### PR DESCRIPTION
<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/docs/tsduck-dev.html#chap-contribution
-->

#### Related issue (if any):
<!-- Reference any existing TSDuck issue using the #nnn notation -->

#### Affected components:
<!-- TSDuck command name, plugin name or C++ component in the TSDuck library -->

libtscore

#### Brief description of the proposed changes:

time.h header is not exposed by default on macOS, so add header reference.
