### PR TITLE
scripts: support sourcing setenv.sh from zsh

### DIFF
--- a/scripts/setenv.sh
+++ b/scripts/setenv.sh
@@ -16,7 +16,16 @@
 #
 #-----------------------------------------------------------------------------
 
-SCRIPT=$(basename "${BASH_SOURCE[0]}")
+if [ -n "${BASH_VERSION:-}" ]; then
+    THIS_SCRIPT="${BASH_SOURCE[0]}"
+elif [ -n "${ZSH_VERSION:-}" ]; then
+    # shellcheck disable=SC2296
+    THIS_SCRIPT="${(%):-%x}"
+else
+    THIS_SCRIPT="$0"
+fi
+
+SCRIPT=$(basename "$THIS_SCRIPT")
 usage() { echo >&2 "syntax: $SCRIPT [--bin dir] [--debug] [--display] [-all]"; exit 1; }
 
 # Default options.
@@ -49,7 +58,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Build binary directory.
-ROOTDIR=$(cd $(dirname "${BASH_SOURCE[0]}")/..; pwd)
+ROOTDIR=$(cd "$(dirname "$THIS_SCRIPT")/.." || exit; pwd)
 TSPYDIR="$ROOTDIR/src/libtsduck/python"
 if [[ -z "$BINDIR" ]]; then
     ARCH=$(uname -m | sed -e 's/i.86/i386/' -e 's/^arm.*$/arm/' -e 's/ /-/g')
@@ -61,12 +70,18 @@ fi
 addpath() {
     local varname=$1
     local bindir="$2"
-    local npath=":${!varname}:"
+    local current_path
+    eval "current_path=\"\$$varname\""
+    local npath=":${current_path}:"
     npath="${npath//:$bindir:/:}"
     npath="${npath//::/:}"
     npath="${npath/#:/}"
     npath="${npath/%:/}"
-    [[ -z "$npath" ]] && export $varname="$bindir:" || export $varname="$bindir:$npath:"
+    if [[ -z "$npath" ]]; then
+        export "$varname=$bindir"
+    else
+        export "$varname=$bindir:$npath"
+    fi
 }
 
 # Display or set path.


### PR DESCRIPTION
<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/docs/tsduck-dev.html#chap-contribution
-->

#### Related issue (if any):
#1701

#### Affected components:
`scripts/setenv.sh`

#### Brief description of the proposed changes:
This PR updates the `scripts/setenv.sh` utility so that it can be safely and reliably sourced from zsh as well as bash. The script previously relied on bash-specific features (`BASH_SOURCE[0]` and indirect variable expansion `${!varname}`), which triggered errors when executed in zsh (the default shell on macOS).
Specific changes include:
- Implementing shell-agnostic path resolution for `THIS_SCRIPT` using `$ZSH_VERSION` and `$BASH_VERSION`.
- Replacing the bash-only indirect expansion with a safe `eval` equivalent that works correctly across different shells.
- Fixing warnings raised by shellcheck

#### Tested Env:
- macOS 26.4
- Shells:
  - zsh 5.9 (arm64-apple-darwin25.0)
  - GNU bash, version 5.3.9(1)-release (aarch64-apple-darwin25.1.0)
  - GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25) (SH)

