### PR TITLE
feat(dsmcc): bootstrap ServiceGateway location from DSI IOR

### DIFF
--- a/src/libtsduck/dtv/dsmcc/tsDSMCCCarousel.cpp
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCCarousel.cpp
@@ -58,6 +58,45 @@ void ts::DSMCCCarousel::flushPendingObjects()
 }
 
 
+void ts::DSMCCCarousel::feedUserToNetwork(const DSMCCUserToNetworkMessage& unm)
+{
+    // SRG bootstrap only applies to object carousels. In data-carousel mode
+    // (DVB-SSU, etc.) the DSI's private_data is a GroupInfoIndication, not an
+    // IOR pointing to a ServiceGateway — the upstream UNM parser reads it as
+    // an IOR regardless, so dsi.ior would be garbage here. Skip bootstrap; the
+    // assembler still consumes DII as usual.
+    if (_scan_biop) {
+        if (const auto* dsi = unm.toDSI()) {
+            bootstrapFromDSI(*dsi);
+        }
+    }
+    _assembler.feedUserToNetwork(unm);
+}
+
+
+// Extract the ServiceGateway location from the DSI's IOR and pre-seed it as a
+// root in the name resolver. If nothing matches, we leave the scan fallback in
+// scanBIOPObjects() to catch the SRG when its module is parsed.
+void ts::DSMCCCarousel::bootstrapFromDSI(const DSMCCUserToNetworkMessage::DownloadServerInitiate& dsi)
+{
+    for (const auto& tp : dsi.ior.tagged_profiles) {
+        if (tp.profile_id_tag != DSMCC_TAG_BIOP) {
+            continue;
+        }
+        for (const auto& lc : tp.lite_components) {
+            if (lc.component_id_tag != DSMCC_TAG_OBJECT_LOCATION) {
+                continue;
+            }
+            _names.addRoot({lc.module_id, lc.object_key_data});
+            _duck.report().verbose(u"DSI bootstrap: ServiceGateway at carousel_id=0x%X module_id=0x%X (object_key %d bytes)",
+                                   lc.carousel_id, lc.module_id, lc.object_key_data.size());
+            return;
+        }
+    }
+    _duck.report().verbose(u"DSI bootstrap: no BIOP ObjectLocation in IOR, falling back to module scan");
+}
+
+
 void ts::DSMCCCarousel::onAssemblerModuleComplete(const DSMCCModuleAssembler::ModuleContext& ctx)
 {
     ByteBlock payload;

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCCarousel.h
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCCarousel.h
@@ -44,9 +44,12 @@ namespace ts {
 
         //!
         //! Feed a DSM-CC User-to-Network Message (DSI or DII).
+        //! For a DSI, the carousel engine extracts the ServiceGateway location
+        //! from the IOR and pre-seeds the name resolver so path resolution works
+        //! as soon as the SRG module arrives.
         //! @param [in] unm The parsed message.
         //!
-        void feedUserToNetwork(const DSMCCUserToNetworkMessage& unm) { _assembler.feedUserToNetwork(unm); }
+        void feedUserToNetwork(const DSMCCUserToNetworkMessage& unm);
 
         //!
         //! Feed a DSM-CC Download Data Message (DDB).
@@ -113,5 +116,6 @@ namespace ts {
 
         void onAssemblerModuleComplete(const DSMCCModuleAssembler::ModuleContext& ctx);
         void scanBIOPObjects(uint16_t module_id, const ByteBlock& payload);
+        void bootstrapFromDSI(const DSMCCUserToNetworkMessage::DownloadServerInitiate& dsi);
     };
 }  // namespace ts


### PR DESCRIPTION
#### Related issue (if any):
Follow-up to #1704
#82

#### Affected components:
- `DSMCCCarousel` (new `bootstrapFromDSI`, `feedUserToNetwork` now out-of-line)

#### Brief description of the proposed changes:
Use the DSI's IOR to pre-seed the ServiceGateway location in the BIOPname resolver, instead of waiting for `scanBIOPObjects` to notice the `srg` kind tag in a completed module.