### PR TITLE
feat(dsmcc): parse GroupInfoIndication in data-carousel DSIs

### DIFF
--- a/src/libtsduck/dtv/dsmcc/ROADMAP.md
+++ b/src/libtsduck/dtv/dsmcc/ROADMAP.md
@@ -78,13 +78,11 @@ there from the signalling:
 Enough to pull bytes off a DVB-SSU stream, but it drops most of the
 structure the spec gives us:
 
-- [ ] **`GroupInfoIndication` parsing.** DSI's `private_data` in
+- [x] **`GroupInfoIndication` parsing.** DSI's `private_data` in
   data-carousel mode carries a `GroupInfoIndication` listing the
   carousel's groups (not an IOR). The UNM table parser currently
   always reads it as an IOR; proper dispatch by carousel type is
   needed.
-- [ ] **`SuperGroupInfoIndication`** for the (rarer) case where groups
-  are themselves grouped.
 - [ ] **Group hierarchy.** Track groups as first-class citizens; expose
   `carousel → group → module` instead of the flat module list.
 - [ ] **Group-scoped module ids.** Today modules are keyed purely by

--- a/src/libtsduck/dtv/dsmcc/tsDSMCC.names
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCC.names
@@ -65,11 +65,14 @@ Bits = 16
 0x80b0 = ServerSessionInProgressRequest
 
 [DSMCC.descriptorType]
-# ISO/IEC 13818-6, 6.1
+# ISO/IEC 13818-6, 6.1; DVB-reserved range from ETSI TR 101 202.
 Bits = 8
-0x00 = Pad descriptor
-0x01 = System Hardware descriptor
-0x02 = System Software descriptor
+0x00      = Pad descriptor
+0x01      = System Hardware descriptor
+0x02      = System Software descriptor
+0x03-0x3F = ISO/IEC 13818-6 reserved
+0x40-0x7F = DVB reserved
+0x80-0xFF = User defined
 
 [DSMCC.specifierType]
 # ISO/IEC 13818-6, 6.1

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCCarousel.cpp
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCCarousel.cpp
@@ -60,14 +60,17 @@ void ts::DSMCCCarousel::flushPendingObjects()
 
 void ts::DSMCCCarousel::feedUserToNetwork(const DSMCCUserToNetworkMessage& unm)
 {
-    // SRG bootstrap only applies to object carousels. In data-carousel mode
-    // (DVB-SSU, etc.) the DSI's private_data is a GroupInfoIndication, not an
-    // IOR pointing to a ServiceGateway — the upstream UNM parser reads it as
-    // an IOR regardless, so dsi.ior would be garbage here. Skip bootstrap; the
-    // assembler still consumes DII as usual.
-    if (_scan_biop) {
-        if (const auto* dsi = unm.toDSI()) {
+    if (const auto* dsi = unm.toDSI()) {
+        // Object-carousel DSI: ior is populated, bootstrap the SRG location.
+        // Data-carousel DSI: group_info is populated; log a per-group summary.
+        if (_scan_biop) {
             bootstrapFromDSI(*dsi);
+        }
+        else if (!dsi->group_info.groups.empty()) {
+            for (const auto& group : dsi->group_info.groups) {
+                _duck.report().verbose(u"DSI group: id=0x%X, size=%d, %d compatibility descriptor(s)",
+                                       group.group_id, group.group_size, group.group_compatibility.descs.size());
+            }
         }
     }
     _assembler.feedUserToNetwork(unm);

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCGroupInfoIndication.cpp
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCGroupInfoIndication.cpp
@@ -1,0 +1,108 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2026, Piotr Serafin
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+
+#include "tsDSMCCGroupInfoIndication.h"
+#include "tsPSIBuffer.h"
+#include "tsTablesDisplay.h"
+#include "tsxmlElement.h"
+
+
+void ts::DSMCCGroupInfoIndication::clear()
+{
+    groups.clear();
+    private_data.clear();
+}
+
+
+void ts::DSMCCGroupInfoIndication::serialize(PSIBuffer& buf) const
+{
+    buf.putUInt16(uint16_t(groups.size()));
+    for (const auto& group : groups) {
+        buf.putUInt32(group.group_id);
+        buf.putUInt32(group.group_size);
+        group.group_compatibility.serialize(buf);
+        buf.putUInt16(uint16_t(group.group_info.size()));
+        buf.putBytes(group.group_info);
+    }
+    buf.putUInt16(uint16_t(private_data.size()));
+    buf.putBytes(private_data);
+}
+
+
+void ts::DSMCCGroupInfoIndication::deserialize(PSIBuffer& buf)
+{
+    clear();
+    const uint16_t number_of_groups = buf.getUInt16();
+    for (size_t i = 0; i < number_of_groups && !buf.error(); ++i) {
+        Group& group(groups.emplace_back());
+        group.group_id = buf.getUInt32();
+        group.group_size = buf.getUInt32();
+        group.group_compatibility.deserialize(buf);
+        const uint16_t group_info_length = buf.getUInt16();
+        buf.getBytes(group.group_info, group_info_length);
+    }
+    const uint16_t private_data_length = buf.getUInt16();
+    buf.getBytes(private_data, private_data_length);
+}
+
+
+void ts::DSMCCGroupInfoIndication::Display(TablesDisplay& disp, PSIBuffer& buf, const UString& margin)
+{
+    if (!buf.canReadBytes(2)) {
+        return;
+    }
+    const uint16_t number_of_groups = buf.getUInt16();
+    disp << margin << UString::Format(u"Number of groups: %d", number_of_groups) << std::endl;
+
+    for (size_t i = 0; i < number_of_groups && buf.canReadBytes(8); ++i) {
+        const uint32_t group_id = buf.getUInt32();
+        const uint32_t group_size = buf.getUInt32();
+        disp << margin << UString::Format(u"- Group #%d, id: %n, size: %n", i, group_id, group_size) << std::endl;
+        DSMCCCompatibilityDescriptor::Display(disp, buf, margin + u"  ");
+        if (buf.canReadBytes(2)) {
+            const size_t group_info_length = buf.getUInt16();
+            disp.displayPrivateData(u"Group info", buf, group_info_length, margin + u"  ");
+        }
+    }
+
+    if (buf.canReadBytes(2)) {
+        const size_t private_data_length = buf.getUInt16();
+        disp.displayPrivateData(u"Private data", buf, private_data_length, margin);
+    }
+}
+
+
+void ts::DSMCCGroupInfoIndication::toXML(DuckContext& duck, xml::Element* parent) const
+{
+    xml::Element* gii_element = parent->addElement(u"GroupInfoIndication");
+    for (const auto& group : groups) {
+        xml::Element* xgroup = gii_element->addElement(u"group");
+        xgroup->setIntAttribute(u"group_id", group.group_id, true);
+        xgroup->setIntAttribute(u"group_size", group.group_size, true);
+        group.group_compatibility.toXML(duck, xgroup, true);
+        xgroup->addHexaTextChild(u"group_info", group.group_info, true);
+    }
+    gii_element->addHexaTextChild(u"private_data", private_data, true);
+}
+
+
+bool ts::DSMCCGroupInfoIndication::fromXML(DuckContext& duck, const xml::Element* element)
+{
+    clear();
+    bool ok = true;
+    for (auto& xgroup : element->children(u"group", &ok)) {
+        Group& group(groups.emplace_back());
+        ok = ok &&
+             xgroup.getIntAttribute(group.group_id, u"group_id", true) &&
+             xgroup.getIntAttribute(group.group_size, u"group_size", true) &&
+             group.group_compatibility.fromXML(duck, &xgroup, false) &&
+             xgroup.getHexaTextChild(group.group_info, u"group_info", false);
+    }
+    ok = ok && element->getHexaTextChild(private_data, u"private_data", false);
+    return ok;
+}

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCGroupInfoIndication.h
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCGroupInfoIndication.h
@@ -85,7 +85,7 @@ namespace ts {
         //!
         //! Decode the GroupInfoIndication from XML.
         //! @param [in,out] duck TSDuck execution context.
-        //! @param [in] element The XML <GroupInfoIndication> element.
+        //! @param [in] element The XML GroupInfoIndication element.
         //! @return True on success, false on error.
         //!
         bool fromXML(DuckContext& duck, const xml::Element* element);

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCGroupInfoIndication.h
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCGroupInfoIndication.h
@@ -1,0 +1,93 @@
+//----------------------------------------------------------------------------
+//
+// TSDuck - The MPEG Transport Stream Toolkit
+// Copyright (c) 2005-2026, Piotr Serafin
+// BSD-2-Clause license, see LICENSE.txt file or https://tsduck.io/license
+//
+//----------------------------------------------------------------------------
+//!
+//!  @file
+//!  DSM-CC GroupInfoIndication structure (DSI userInfo for data carousels).
+//!
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "tsDSMCCCompatibilityDescriptor.h"
+
+namespace ts {
+    //!
+    //! Representation of a DSM-CC GroupInfoIndication structure.
+    //!
+    //! Carried as the userInfo of a DownloadServerInitiate (DSI) message when the
+    //! download is a data carousel (rather than an object carousel). One entry
+    //! per group, each with its own groupCompatibility() descriptor.
+    //!
+    //! @see ISO/IEC 13818-6
+    //! @see ETSI EN 301 192 V1.7.1 (2021-08), 10.1.2
+    //! @ingroup libtsduck mpeg
+    //!
+    class TSDUCKDLL DSMCCGroupInfoIndication
+    {
+    public:
+        //!
+        //! One group entry inside a GroupInfoIndication.
+        //!
+        class TSDUCKDLL Group
+        {
+        public:
+            Group() = default;                                       //!< Default constructor.
+            uint32_t group_id = 0;                                   //!< Identifier of the group.
+            uint32_t group_size = 0;                                 //!< Size of the group, in bytes.
+            DSMCCCompatibilityDescriptor group_compatibility {};     //!< Per-group compatibilityDescriptor.
+            ByteBlock group_info {};                                 //!< Application-defined groupInfo bytes.
+        };
+
+        std::list<Group> groups {};      //!< List of groups.
+        ByteBlock private_data {};       //!< Trailing privateData bytes.
+
+        //!
+        //! Default constructor.
+        //!
+        DSMCCGroupInfoIndication() = default;
+
+        //!
+        //! Clear the structure.
+        //!
+        void clear();
+
+        //!
+        //! Serialize the GroupInfoIndication.
+        //! @param [in,out] buf Serialization buffer.
+        //!
+        void serialize(PSIBuffer& buf) const;
+
+        //!
+        //! Deserialize the GroupInfoIndication.
+        //! @param [in,out] buf Deserialization buffer.
+        //!
+        void deserialize(PSIBuffer& buf);
+
+        //!
+        //! Display the GroupInfoIndication.
+        //! @param [in,out] display Display engine.
+        //! @param [in,out] buf A PSIBuffer over the GroupInfoIndication.
+        //! @param [in] margin Left margin content.
+        //!
+        static void Display(TablesDisplay& display, PSIBuffer& buf, const UString& margin);
+
+        //!
+        //! Convert the GroupInfoIndication to XML.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in,out] parent The parent node for the XML element.
+        //!
+        void toXML(DuckContext& duck, xml::Element* parent) const;
+
+        //!
+        //! Decode the GroupInfoIndication from XML.
+        //! @param [in,out] duck TSDuck execution context.
+        //! @param [in] element The XML <GroupInfoIndication> element.
+        //! @return True on success, false on error.
+        //!
+        bool fromXML(DuckContext& duck, const xml::Element* element);
+    };
+}  // namespace ts

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCGroupInfoIndication.xml
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCGroupInfoIndication.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsduck>
+  <_dsmccGroupInfoIndication>
+
+    <!-- DSM-CC GroupInfoIndication structure -->
+    <GroupInfoIndication>
+      <group group_id="uint32, required"
+             group_size="uint32, required">
+        <_any in="_dsmccCompatibilityDescriptor"/>
+        <group_info>
+          Hexadecimal content
+        </group_info>
+      </group>
+      <private_data>
+        Hexadecimal content
+      </private_data>
+    </GroupInfoIndication>
+
+  </_dsmccGroupInfoIndication>
+</tsduck>

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.adoc
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.adoc
@@ -35,6 +35,7 @@ Defined by MPEG in <<ISO-13818-6>>.
       </descriptor>
     </compatibilityDescriptor>
 
+    <!-- DSM-CC IOR() structure (object-carousel DSI body) -->
     <IOR>
       <type_id>
         Hexadecimal content
@@ -90,6 +91,33 @@ Defined by MPEG in <<ISO-13818-6>>.
         </Unknown_profile_body>
       </tagged_profile>
     </IOR>
+
+    <!-- DSM-CC GroupInfoIndication() structure (data-carousel DSI body) -->
+    <GroupInfoIndication>
+      <!-- Zero or more groups -->
+      <group group_id="uint32, required" group_size="uint32, required">
+        <compatibilityDescriptor>
+          <!-- Zero or more descriptors -->
+          <descriptor
+              descriptorType="uint8, required"
+              specifierType="uint8, default=1"
+              specifierData="uint24, required"
+              model="uint16, default=0"
+              version="uint16, default=0">
+            <!-- Zero or more subdescriptors -->
+            <subDescriptor subDescriptorType="uint8, required">
+              Hexadecimal content
+            </subDescriptor>
+          </descriptor>
+        </compatibilityDescriptor>
+        <group_info>
+          Hexadecimal content
+        </group_info>
+      </group>
+      <private_data>
+        Hexadecimal content
+      </private_data>
+    </GroupInfoIndication>
 
   </DSI>
 

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.cpp
@@ -22,6 +22,26 @@
 TS_REGISTER_TABLE(MY_CLASS, {MY_TID}, MY_STD, MY_XML_NAME, MY_CLASS::DisplaySection);
 
 
+namespace {
+    // Object Carousel DSI's IOR has type_id == "srg".
+    // Wire layout: type_id_length(32) | 's' 'r' 'g' | pad. Inspect the next
+    // 7+ bytes without consuming them; if they match, treat the DSI's
+    // private_data as an IOR, otherwise as a GroupInfoIndication.
+    bool LooksLikeObjectCarouselDSI(const uint8_t* private_data, size_t size)
+    {
+        if (size < 7) {
+            return false;
+        }
+        const uint32_t type_id_length =
+            (uint32_t(private_data[0]) << 24) |
+            (uint32_t(private_data[1]) << 16) |
+            (uint32_t(private_data[2]) << 8) |
+             uint32_t(private_data[3]);
+        return type_id_length == 4 && private_data[4] == 's' && private_data[5] == 'r' && private_data[6] == 'g';
+    }
+}
+
+
 //----------------------------------------------------------------------------
 // Constructors and assignment.
 //----------------------------------------------------------------------------
@@ -166,9 +186,12 @@ void ts::DSMCCUserToNetworkMessage::deserializePayload(PSIBuffer& buf, const Sec
         // Private_data_length
         buf.pushReadSizeFromLength(16);  // private_data_length
 
-        dsi.ior.deserialize(buf);
-
-        buf.skipBytes(4);  // download_taps_count + service_context_list_count + user_info_length
+        if (LooksLikeObjectCarouselDSI(buf.currentReadAddress(), buf.remainingReadBytes())) {
+            dsi.ior.deserialize(buf); // Object carousel: IOR
+            buf.skipBytes(4);  // download_taps_count + service_context_list_count + user_info_length
+        } else {
+            dsi.group_info.deserialize(buf); // Data carousel: GroupInfoIndication
+        }
 
         buf.popState();
     }
@@ -248,12 +271,15 @@ void ts::DSMCCUserToNetworkMessage::serializePayload(BinaryTable& table, PSIBuff
 
         buf.pushWriteSequenceWithLeadingLength(16);  // private_data
 
-        // IOP::IOR
-        dsi->ior.serialize(buf);
-
-        buf.putUInt8(0x00);     // download_taps_count
-        buf.putUInt8(0x00);     // service_context_list_count
-        buf.putUInt16(0x0000);  // user_info_length
+        if (!dsi->group_info.groups.empty()) {
+            dsi->group_info.serialize(buf);
+        }
+        else {
+            dsi->ior.serialize(buf);
+            buf.putUInt8(0x00);     // download_taps_count
+            buf.putUInt8(0x00);     // service_context_list_count
+            buf.putUInt16(0x0000);  // user_info_length
+        }
 
         buf.popState();  // close private_data
     }
@@ -355,15 +381,20 @@ void ts::DSMCCUserToNetworkMessage::DisplaySection(TablesDisplay& disp, const ts
         DSMCCCompatibilityDescriptor::Display(disp, buf, margin);
         buf.pushReadSizeFromLength(16);  //private_data_length
 
-        DSMCCIOR::Display(disp, buf, margin);
+        if (LooksLikeObjectCarouselDSI(buf.currentReadAddress(), buf.remainingReadBytes())) {
+            DSMCCIOR::Display(disp, buf, margin);
 
-        uint8_t download_taps_count = buf.getUInt8();
-        uint8_t service_context_list_count = buf.getUInt8();
-        uint16_t user_info_length = buf.getUInt16();
+            uint8_t download_taps_count = buf.getUInt8();
+            uint8_t service_context_list_count = buf.getUInt8();
+            uint16_t user_info_length = buf.getUInt16();
 
-        disp << margin << UString::Format(u"Download taps count: %n", download_taps_count) << std::endl;
-        disp << margin << UString::Format(u"Service context list count: %n", service_context_list_count) << std::endl;
-        disp << margin << UString::Format(u"User info length: %n", user_info_length) << std::endl;
+            disp << margin << UString::Format(u"Download taps count: %n", download_taps_count) << std::endl;
+            disp << margin << UString::Format(u"Service context list count: %n", service_context_list_count) << std::endl;
+            disp << margin << UString::Format(u"User info length: %n", user_info_length) << std::endl;
+        }
+        else {
+            DSMCCGroupInfoIndication::Display(disp, buf, margin);
+        }
 
         buf.popState();
     }
@@ -443,7 +474,12 @@ void ts::DSMCCUserToNetworkMessage::buildXML(DuckContext& duck, xml::Element* ro
         dsi_xml->addHexaTextChild(u"server_id", dsi->server_id, true);
         compatibility_descriptor.toXML(duck, dsi_xml, true);
 
-        dsi->ior.toXML(duck, dsi_xml);
+        if (!dsi->group_info.groups.empty()) {
+            dsi->group_info.toXML(duck, dsi_xml);
+        }
+        else {
+            dsi->ior.toXML(duck, dsi_xml);
+        }
     }
     else if (const auto* dii = toDII()) {
 
@@ -495,12 +531,23 @@ bool ts::DSMCCUserToNetworkMessage::analyzeXML(DuckContext& duck, const xml::Ele
         ok = dsi_element->getHexaTextChild(dsi.server_id, u"server_id") &&
             compatibility_descriptor.fromXML(duck, dsi_element, false);
 
-        const xml::Element* ior_element = dsi_element->findFirstChild(u"IOR", true);
-        if (!ok || ior_element == nullptr) {
+        if (!ok) {
             return false;
         }
 
-        ok = dsi.ior.fromXML(duck, ior_element);
+        // Accept either an <IOR> child (object carousel) or a <GroupInfoIndication> child (data carousel).
+        const xml::Element* ior_element = dsi_element->findFirstChild(u"IOR", false);
+        const xml::Element* gii_element = dsi_element->findFirstChild(u"GroupInfoIndication", false);
+
+        if (ior_element != nullptr) {
+            ok = dsi.ior.fromXML(duck, ior_element);
+        }
+        else if (gii_element != nullptr) {
+            ok = dsi.group_info.fromXML(duck, gii_element);
+        }
+        else {
+            return false;
+        }
     }
     else if (header.message_id == DSMCC_MSGID_DII) {
         const xml::Element* dii_element = element->findFirstChild(u"DII", true);

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.h
@@ -17,6 +17,7 @@
 #include "tsDSMCCTap.h"
 #include "tsDSMCCCompatibilityDescriptor.h"
 #include "tsDSMCCIOR.h"
+#include "tsDSMCCGroupInfoIndication.h"
 
 namespace ts {
     //!
@@ -61,8 +62,9 @@ namespace ts {
         //! DSM-CC DownloadServerInitiate (DSI) message body.
         //!
         struct TSDUCKDLL DownloadServerInitiate {
-            ByteBlock server_id {};  //!< Field shall be set to 20 bytes with the value 0xFF.
-            DSMCCIOR ior {};         //!< Interoperable Object Reference (IOR) structure.
+            ByteBlock server_id {};                 //!< Field shall be set to 20 bytes with the value 0xFF.
+            DSMCCIOR ior {};                        //!< IOR structure (object carousel; populated when type_id == "srg").
+            DSMCCGroupInfoIndication group_info {}; //!< GroupInfoIndication (data carousel; populated otherwise).
 
             //!
             //! Reset the DSI body to its default state.
@@ -71,6 +73,7 @@ namespace ts {
             {
                 server_id.clear();
                 ior.clear();
+                group_info.clear();
             }
         };
 

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.xml
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCUserToNetworkMessage.xml
@@ -14,12 +14,14 @@
       <_any in="_metadata"/>
 
       <!-- required when message_id == 0x1006 (DownloadServerInitiate) -->
+      <!-- exactly one of <IOR> (object carousel) or <GroupInfoIndication> (data carousel) -->
       <DSI>
         <server_id>
           Hexadecimal content
         </server_id>
         <_any in="_dsmccCompatibilityDescriptor"/>
         <_any in="_dsmccIOR"/>
+        <_any in="_dsmccGroupInfoIndication"/>
       </DSI>
 
       <!-- required when message_id == 0x1002 (DownloadInfoIndication) -->


### PR DESCRIPTION
<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/docs/tsduck-dev.html#chap-contribution
-->

#### Related issue (if any):
#82 
https://github.com/tsduck/tsduck-test/pull/54

#### Brief description of the proposed changes:
Add support for parsing GroupInfoIndication structure in DSI when data carousel detected. 
