### PR TITLE
feat(dsmcc): render DSI-level compatibilityDescriptor, tighten list output

### DIFF
--- a/doc/user/examples/dsmcc.adoc
+++ b/doc/user/examples/dsmcc.adoc
@@ -100,47 +100,37 @@ file/directory tree and byte sizes:
   Download id: 0x0000000A (10)
   Modules discovered: 3
   Group complete: yes
-
   - Module 0x0001
     Version: 125, blocks: 1
     Size: 133 bytes, original size: 294 bytes
     Compression: yes
     Status: COMPLETE
-
     BIOP objects: 1
     - Object 0: "/" [srg]
-
     - Descriptor 0: Compressed Module, 5 bytes
       Compression method: 0x78
       Original size: 294 bytes
-
   - Module 0x0002
     Version: 125, blocks: 94
     Size: 379138 bytes, original size: 756113 bytes
     Compression: yes
     Status: COMPLETE
-
     BIOP objects: 1
     - Object 0: "/deja.ttf" [fil]
-
     - Descriptor 0: Compressed Module, 5 bytes
       Compression method: 0x78
       Original size: 756113 bytes
-
   - Module 0x0003
     Version: 125, blocks: 8
     Size: 29806 bytes, original size: 31946 bytes
     Compression: yes
     Status: COMPLETE
-
     BIOP objects: 2
     - Object 0: "/index.html" [fil]
     - Object 1: "/rj45.gif" [fil]
-
     - Descriptor 0: Compressed Module, 5 bytes
       Compression method: 0x78
       Original size: 31946 bytes
-
 
 * Carousel Tree
   /

--- a/doc/user/examples/dsmcc.adoc
+++ b/doc/user/examples/dsmcc.adoc
@@ -99,6 +99,7 @@ file/directory tree and byte sizes:
 * DSM-CC Carousel, PID 0x076A (1898)
   Download id: 0x0000000A (10)
   Modules discovered: 3
+  Modules complete: 3 / 3
   Group complete: yes
   - Module 0x0001
     Version: 125, blocks: 1
@@ -201,6 +202,49 @@ out
 
 This is useful to feed the raw BIOP payload to an external parser, or to
 diff two captures of the same carousel at byte level.
+
+==== Listing a data carousel
+
+`--data-carousel` also works in list-only mode (no `--output-directory`).
+BIOP-object lines and the `Carousel Tree` are omitted; the group-level
+`compatibilityDescriptor()` is surfaced instead, naming the target
+hardware/software via DSM-CC descriptor types and an IEEE OUI specifier
+(see <<ISO-13818-6>> 6.1):
+
+[source,shell]
+----
+$ tsdsmcc --pid 0x189 --data-carousel update.ts
+----
+
+[source,text]
+----
+* DSM-CC Carousel, PID 0x0189 (393)
+  Download id: 0x80000002 (2147483650)
+  Modules discovered: 1
+  Modules complete: 1 / 1
+  Group complete: yes
+  Compatibility descriptor: 3 descriptor(s)
+    - Descriptor 0: type 0x01 (System Hardware descriptor)
+      Specifier type: 0x01 (IEEE OUI)
+      Specifier data: 0x00237C (NEOTION)
+      Model: 0x0088, Version: 0x0016
+      Subdescriptors: 0
+    - Descriptor 1: type 0x02 (System Software descriptor)
+      Specifier type: 0x01 (IEEE OUI)
+      Specifier data: 0x00237C (NEOTION)
+      Model: 0x0180, Version: 0x0002
+      Subdescriptors: 0
+    - Descriptor 2: type 0x40 (DVB reserved)
+      Specifier type: 0x01 (IEEE OUI)
+      Specifier data: 0x00237C (NEOTION)
+      Model: 0x0000, Version: 0x0000
+      Subdescriptors: 0
+  - Module 0x0200
+    Version: 0, blocks: 90
+    Size: 362592 bytes
+    Compression: no
+    Status: COMPLETE
+----
 
 ==== Extracting a data carousel (DVB-SSU)
 

--- a/src/libtsduck/dtv/dsmcc/ROADMAP.md
+++ b/src/libtsduck/dtv/dsmcc/ROADMAP.md
@@ -92,12 +92,14 @@ structure the spec gives us:
   CRC32/location/est_download_time/group_link/compressed_module/
   ssu_module_type/subgroup_association/label/caching_priority/
   content_type) are decoded in the list-only report.
-- [ ] **Wire group/carousel-level descriptors into the extractor.**
-  `GroupContext.compatibility` is populated from the DSI but
-  `renderGroupBlock` does not print it. Surface the group's
-  `compatibilityDescriptor()` (specifier/OUI, model, version,
-  sub-descriptors).
-- [ ] **Per-group completeness stats** alongside the per-module ones.
+- [x] **Wire group/carousel-level descriptors into the extractor.**
+  `renderGroupBlock` now prints the group's
+  `compatibilityDescriptor()` (descriptor type, specifier type/data,
+  model, version, sub-descriptor types and sizes) when
+  `GroupContext.compatibility` is non-empty.
+- [x] **Per-group completeness stats** alongside the per-module ones.
+  `renderGroupBlock` prints `Modules complete: X / Y` derived from
+  `GroupContext.modules_complete` / `module_ids.size()`.
 - [x] **Output layout.** The data-carousel writer mirrors the
   carousel's group hierarchy on disk
   (`<out>/<download_id>/<label_or_module_XXXX>.bin`) and uses the

--- a/src/libtsduck/dtv/dsmcc/ROADMAP.md
+++ b/src/libtsduck/dtv/dsmcc/ROADMAP.md
@@ -87,14 +87,21 @@ structure the spec gives us:
   `carousel → group → module` instead of the flat module list.
 - [x] **Group-scoped module ids.** Today modules are keyed purely by
   `module_id`; a multi-group carousel requires `(group_id, module_id)`.
-- [ ] **Wire module/group/carousel descriptors into the extractor.**
-  The descriptor classes already exist under but `DSMCCExtractor`
-  only looks up `compressed_module_descriptor`. Extend the DII
-  handling to surface the rest.
+- [x] **Wire module-level DII descriptors into the extractor.** All 14
+  DSM-CC module-info descriptor types (type/name/info/module_link/
+  CRC32/location/est_download_time/group_link/compressed_module/
+  ssu_module_type/subgroup_association/label/caching_priority/
+  content_type) are decoded in the list-only report.
+- [ ] **Wire group/carousel-level descriptors into the extractor.**
+  `GroupContext.compatibility` is populated from the DSI but
+  `renderGroupBlock` does not print it. Surface the group's
+  `compatibilityDescriptor()` (specifier/OUI, model, version,
+  sub-descriptors).
 - [ ] **Per-group completeness stats** alongside the per-module ones.
-- [ ] **Output layout.** Mirror the group hierarchy on disk and use
-  `label_descriptor` contents when present, so data-carousel output
-  is self-describing.
+- [x] **Output layout.** The data-carousel writer mirrors the
+  carousel's group hierarchy on disk
+  (`<out>/<download_id>/<label_or_module_XXXX>.bin`) and uses the
+  module's `label_descriptor` contents for the leaf name when present.
 
 ## Output
 

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.cpp
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.cpp
@@ -249,7 +249,9 @@ std::optional<std::filesystem::path> ts::DSMCCExtractor::safeOutputPath(const US
 void ts::DSMCCExtractor::printListSummary()
 {
     UString text = renderCarousels();
-    text += renderFileTreeFinal();
+    if (!_options.data_carousel) {
+        text += renderFileTreeFinal();
+    }
     _duck.report().info(u"%s", text);
 }
 
@@ -277,7 +279,6 @@ ts::UString ts::DSMCCExtractor::renderGroupBlock(const DSMCCCarousel::GroupConte
             out += renderModuleBlock(*mctx);
         }
     }
-    out += u"\n";
     return out;
 }
 
@@ -289,7 +290,7 @@ ts::UString ts::DSMCCExtractor::renderModuleBlock(const DSMCCModuleAssembler::Mo
         : UString();
 
     UString out;
-    out += UString::Format(u"\n%s- Module 0x%04X\n", u"  ", ctx.module_id);
+    out += UString::Format(u"%s- Module 0x%04X\n", u"  ", ctx.module_id);
     out += UString::Format(u"%sVersion: %d, blocks: %d\n", u"    ", ctx.module_version, ctx.expected_blocks);
     out += UString::Format(u"%sSize: %d bytes%s\n", u"    ", ctx.module_size, size_extra);
     out += UString::Format(u"%sCompression: %s\n", u"    ", ctx.is_compressed ? u"yes" : u"no");
@@ -303,9 +304,12 @@ ts::UString ts::DSMCCExtractor::renderModuleBlock(const DSMCCModuleAssembler::Mo
 ts::UString ts::DSMCCExtractor::renderObjectsForModule(uint32_t download_id, uint16_t module_id) const
 {
     UString out;
+    if (_options.data_carousel) {
+        return out;
+    }
     const auto it = _objects_by_module.find({download_id, module_id});
     const size_t n = (it == _objects_by_module.end()) ? 0 : it->second.size();
-    out += UString::Format(u"\n%sBIOP objects: %d\n", u"    ", n);
+    out += UString::Format(u"%sBIOP objects: %d\n", u"    ", n);
     if (n == 0) {
         return out;
     }
@@ -444,7 +448,7 @@ ts::UString ts::DSMCCExtractor::renderOneDescriptor(size_t index, const Descript
     }
 
     UString out;
-    out += UString::Format(u"\n    - Descriptor %d: %s, %d bytes\n", index, header, bytes);
+    out += UString::Format(u"    - Descriptor %d: %s, %d bytes\n", index, header, bytes);
     out += body;
     return out;
 }

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.cpp
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.cpp
@@ -25,6 +25,9 @@
 #include "tsDSMCCSubgroupAssociationDescriptor.h"
 #include "tsDSMCCGroupLinkDescriptor.h"
 #include "tsDSMCCCompressedModuleDescriptor.h"
+#include "tsNames.h"
+#include "tsOUI.h"
+#include "tsDSMCC.h"
 #include <algorithm>
 #include <filesystem>
 #include <map>
@@ -277,7 +280,12 @@ ts::UString ts::DSMCCExtractor::renderGroupBlock(const DSMCCCarousel::GroupConte
     out += UString::Format(u"* DSM-CC Carousel, PID 0x%04X (%d)\n", _pid, _pid);
     out += UString::Format(u"%sDownload id: 0x%08X (%d)\n", u"  ", gctx.download_id, gctx.download_id);
     out += UString::Format(u"%sModules discovered: %d\n", u"  ", gctx.module_ids.size());
+    out += UString::Format(u"%sModules complete: %d / %d\n", u"  ",
+                           gctx.modules_complete, gctx.module_ids.size());
     out += UString::Format(u"%sGroup complete: %s\n", u"  ", gctx.isComplete() ? u"yes" : u"no");
+    if (!gctx.compatibility.empty()) {
+        out += renderCompatibilityDescriptor(gctx.compatibility);
+    }
     for (uint16_t mid : gctx.module_ids) {
         const auto* mctx = _carousel.module(gctx.download_id, mid);
         if (mctx != nullptr) {
@@ -334,6 +342,34 @@ ts::UString ts::DSMCCExtractor::renderDescriptorList(const DescriptorList& descs
     UString out;
     for (size_t i = 0; i < descs.count(); ++i) {
         out += renderOneDescriptor(i, descs[i]);
+    }
+    return out;
+}
+
+
+ts::UString ts::DSMCCExtractor::renderCompatibilityDescriptor(const DSMCCCompatibilityDescriptor& compat_desc) const
+{
+    UString out;
+    out += UString::Format(u"%sCompatibility descriptor: %d descriptor(s)\n", u"  ", compat_desc.descs.size());
+    size_t idx = 0;
+    for (const auto& desc : compat_desc.descs) {
+        const UString desc_type = NameFromSection(u"dtv", u"DSMCC.descriptorType", desc.descriptorType, NamesFlags::HEX_VALUE_NAME);
+        const UString specifier_type = NameFromSection(u"dtv", u"DSMCC.specifierType", desc.specifierType, NamesFlags::HEX_VALUE_NAME);
+        const UString specifier_data = (desc.specifierType == DSMCC_SPTYPE_OUI)
+            ? OUIName(desc.specifierData, NamesFlags::HEX_VALUE_NAME)
+            : UString::Format(u"0x%06X", desc.specifierData);
+        out += UString::Format(u"    - Descriptor %d: type %s\n", idx, desc_type);
+        out += UString::Format(u"      Specifier type: %s\n", specifier_type);
+        out += UString::Format(u"      Specifier data: %s\n", specifier_data);
+        out += UString::Format(u"      Model: 0x%04X, Version: 0x%04X\n", desc.model, desc.version);
+        out += UString::Format(u"      Subdescriptors: %d\n", desc.subdescs.size());
+        size_t sub_idx = 0;
+        for (const auto& subdesc : desc.subdescs) {
+            out += UString::Format(u"      - Subdescriptor %d: type 0x%02X, %d bytes\n",
+                                   sub_idx, subdesc.subDescriptorType, subdesc.additionalInformation.size());
+            ++sub_idx;
+        }
+        ++idx;
     }
     return out;
 }

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.cpp
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.cpp
@@ -259,8 +259,13 @@ void ts::DSMCCExtractor::printListSummary()
 ts::UString ts::DSMCCExtractor::renderCarousels() const
 {
     UString out;
+    bool first = true;
     for (const auto& [dl, gctx] : _carousel.groups()) {
+        if (!first) {
+            out += u"\n";
+        }
         out += renderGroupBlock(gctx);
+        first = false;
     }
     return out;
 }
@@ -295,7 +300,9 @@ ts::UString ts::DSMCCExtractor::renderModuleBlock(const DSMCCModuleAssembler::Mo
     out += UString::Format(u"%sSize: %d bytes%s\n", u"    ", ctx.module_size, size_extra);
     out += UString::Format(u"%sCompression: %s\n", u"    ", ctx.is_compressed ? u"yes" : u"no");
     out += UString::Format(u"%sStatus: %s\n", u"    ", ctx.isComplete() ? u"COMPLETE" : u"PENDING");
-    out += renderObjectsForModule(ctx.download_id, ctx.module_id);
+    if (!_options.data_carousel) {
+        out += renderObjectsForModule(ctx.download_id, ctx.module_id);
+    }
     out += renderDescriptorList(ctx.descs);
     return out;
 }
@@ -304,9 +311,6 @@ ts::UString ts::DSMCCExtractor::renderModuleBlock(const DSMCCModuleAssembler::Mo
 ts::UString ts::DSMCCExtractor::renderObjectsForModule(uint32_t download_id, uint16_t module_id) const
 {
     UString out;
-    if (_options.data_carousel) {
-        return out;
-    }
     const auto it = _objects_by_module.find({download_id, module_id});
     const size_t n = (it == _objects_by_module.end()) ? 0 : it->second.size();
     out += UString::Format(u"%sBIOP objects: %d\n", u"    ", n);

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.h
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.h
@@ -107,6 +107,7 @@ namespace ts {
         UString renderObjectsForModule(uint32_t download_id, uint16_t module_id) const;
         UString renderDescriptorList(const DescriptorList& descs) const;
         UString renderOneDescriptor(size_t index, const Descriptor& raw) const;
+        UString renderCompatibilityDescriptor(const DSMCCCompatibilityDescriptor& compat_desc) const;
         UString renderFileTreeFinal() const;
         UString moduleFilename(uint32_t download_id, uint16_t module_id) const;
 


### PR DESCRIPTION
<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/docs/tsduck-dev.html#chap-contribution
-->

#### Related issue (if any):
#82 

#### Affected components:
`dsmcc`

#### Brief description of the proposed changes:
- Render DSI-level `compatibilityDescriptor()
- Clean up the list-only output: drop stray blank lines, hide BIOP-only sections in `--data-carousel`

##### Examples

###### Object Carousel
```
~ tsdsmcc -p 0x76A ../../../streams/hotbird_11642H.ts

* DSM-CC Carousel, PID 0x076A (1898)
  Download id: 0x0000000A (10)
  Modules discovered: 3
  Modules complete: 3 / 3
  Group complete: yes
  - Module 0x0001
    Version: 125, blocks: 1
    Size: 133 bytes, original size: 294 bytes
    Compression: yes
    Status: COMPLETE
    BIOP objects: 1
    - Object 0: "/" [srg]
    - Descriptor 0: Compressed Module, 5 bytes
      Compression method: 0x78
      Original size: 294 bytes
  - Module 0x0002
    Version: 125, blocks: 94
    Size: 379138 bytes, original size: 756113 bytes
    Compression: yes
    Status: COMPLETE
    BIOP objects: 1
    - Object 0: "/deja.ttf" [fil]
    - Descriptor 0: Compressed Module, 5 bytes
      Compression method: 0x78
      Original size: 756113 bytes
  - Module 0x0003
    Version: 125, blocks: 8
    Size: 29806 bytes, original size: 31946 bytes
    Compression: yes
    Status: COMPLETE
    BIOP objects: 2
    - Object 0: "/index.html" [fil]
    - Object 1: "/rj45.gif" [fil]
    - Descriptor 0: Compressed Module, 5 bytes
      Compression method: 0x78
      Original size: 31946 bytes

* Carousel Tree
  /
    deja.ttf   (756072 bytes)
    index.html (2497 bytes)
    rj45.gif   (29367 bytes)

  Files: 3
  Total size: 787936 bytes
```
###### Data Carousel
```
~ tsdsmcc -p 0x188 --data-carousel ../../../streams/digitenne-594-2020-06-21.ts

* DSM-CC Carousel, PID 0x0188 (392)
  Download id: 0x80000002 (2147483650)
  Modules discovered: 1
  Modules complete: 1 / 1
  Group complete: yes
  Compatibility descriptor: 3 descriptor(s)
    - Descriptor 0: type 0x01 (System Hardware descriptor)
      Specifier type: 0x01 (IEEE OUI)
      Specifier data: 0x00163C (Rebox B.V)
      Model: 0x00EC, Version: 0x0003
      Subdescriptors: 0
    - Descriptor 1: type 0x02 (System Software descriptor)
      Specifier type: 0x01 (IEEE OUI)
      Specifier data: 0x00163C (Rebox B.V)
      Model: 0x0180, Version: 0x001C
      Subdescriptors: 0
    - Descriptor 2: type 0x40 (DVB reserved)
      Specifier type: 0x01 (IEEE OUI)
      Specifier data: 0x00163C (Rebox B.V)
      Model: 0x0000, Version: 0x0000
      Subdescriptors: 0
  - Module 0x0200
    Version: 0, blocks: 25707
    Size: 104523068 bytes
    Compression: no
    Status: COMPLETE
```