### PR TITLE
Fix DSM-CC module extraction for files larger than ~1 MB  (#1719)

### DIFF
--- a/src/libtsduck/dtv/dsmcc/tsDSMCCCarousel.cpp
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCCarousel.cpp
@@ -51,6 +51,7 @@ void ts::DSMCCCarousel::clear()
     _names.clear();
     _groups.clear();
     _module_to_dl.clear();
+    _dsi_bootstrapped = false;
 }
 
 
@@ -75,7 +76,7 @@ void ts::DSMCCCarousel::emitObject(uint16_t module_id, const UString& name, cons
 
 void ts::DSMCCCarousel::feedUserToNetwork(const DSMCCUserToNetworkMessage& unm)
 {
-    if (const auto* dsi = unm.toDSI()) {
+    if (const auto* dsi = unm.toDSI(); dsi != nullptr && !_dsi_bootstrapped) {
         // Object-carousel DSI: ior is populated, bootstrap the SRG location.
         // Data-carousel DSI: group_info is populated; record each group so
         // module-completion accounting can attribute DDBs to the right group.
@@ -92,6 +93,8 @@ void ts::DSMCCCarousel::feedUserToNetwork(const DSMCCUserToNetworkMessage& unm)
 
 void ts::DSMCCCarousel::recordDSIGroups(const DSMCCUserToNetworkMessage::DownloadServerInitiate& dsi)
 {
+    _dsi_bootstrapped = true;
+
     for (const auto& group : dsi.group_info.groups) {
         // group_id == download_id
         GroupContext& ctx = _groups[group.group_id];
@@ -119,6 +122,7 @@ void ts::DSMCCCarousel::bootstrapFromDSI(const DSMCCUserToNetworkMessage::Downlo
                 continue;
             }
             _names.addRoot({comp.module_id, comp.object_key_data});
+            _dsi_bootstrapped = true;
             _duck.report().verbose(u"DSI bootstrap: ServiceGateway at carousel_id=0x%X module_id=0x%X (object_key %d bytes)",
                                    comp.carousel_id, comp.module_id, comp.object_key_data.size());
             return;

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCCarousel.h
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCCarousel.h
@@ -171,6 +171,7 @@ namespace ts {
         GroupHandler _on_group = nullptr;
         BIOPNameResolver _names {};
         bool _scan_biop = true;
+        bool _dsi_bootstrapped = false;
 
         using ModuleToDownloadMap = std::map<uint16_t, uint32_t>;  // module_id -> download_id
 

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.cpp
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.cpp
@@ -10,6 +10,7 @@
 #include "tsDSMCCUserToNetworkMessage.h"
 #include "tsDSMCCDownloadDataMessage.h"
 #include "tsBinaryTable.h"
+#include "tsMemory.h"
 #include "tsDID.h"
 #include "tsDSMCCNameDescriptor.h"
 #include "tsDSMCCTypeDescriptor.h"
@@ -30,8 +31,6 @@
 #include "tsDSMCC.h"
 #include <algorithm>
 #include <filesystem>
-#include <map>
-#include <set>
 
 
 namespace {
@@ -49,7 +48,7 @@ ts::DSMCCExtractor::DSMCCExtractor(DuckContext& duck, const Options& options) :
     _duck(duck),
     _options(options),
     _carousel(duck),
-    _demux(duck, this, nullptr)
+    _demux(duck, nullptr, this)
 {
     _carousel.setScanBIOP(!_options.data_carousel);
 
@@ -95,16 +94,56 @@ void ts::DSMCCExtractor::flush()
 }
 
 
-void ts::DSMCCExtractor::handleTable(SectionDemux&, const BinaryTable& table)
+void ts::DSMCCExtractor::handleSection(SectionDemux&, const Section& section)
 {
-    switch (table.tableId()) {
+    if (!section.isValid() || !section.isLongSection()) {
+        return;
+    }
+
+    switch (section.tableId()) {
         case TID_DSMCC_UNM: {
-            DSMCCUserToNetworkMessage unm(_duck, table);
-            _carousel.feedUserToNetwork(unm);
+            // UNM (DSI/DII): build a single-section BinaryTable and parse.
+            BinaryTable table;
+            table.addNewSection(section, ShareMode::SHARE);
+            if (table.isValid()) {
+                DSMCCUserToNetworkMessage unm(_duck, table);
+                _carousel.feedUserToNetwork(unm);
+            }
             break;
         }
         case TID_DSMCC_DDM: {
-            DSMCCDownloadDataMessage ddm(_duck, table);
+            // DDB: parse section payload directly for per-block assembly.
+            const uint8_t* data = section.payload();
+            const size_t size = section.payloadSize();
+            constexpr size_t MIN_DDB_HEADER = 18;  // 12 (dsmcc header) + 6 (module_id + version + reserved + block_number)
+
+            if (size < MIN_DDB_HEADER) {
+                return;
+            }
+
+            const uint32_t download_id = GetUInt32(data + 4);
+            const uint8_t adaptation_length = data[9];
+
+            const size_t block_fields_offset = 12 + adaptation_length;
+            if (size < block_fields_offset + 6) {
+                return;
+            }
+
+            const uint16_t module_id = GetUInt16(data + block_fields_offset);
+            const uint8_t module_version = data[block_fields_offset + 2];
+            const uint16_t block_number = GetUInt16(data + block_fields_offset + 4);
+
+            const size_t block_data_offset = block_fields_offset + 6;
+            const size_t block_data_size = size - block_data_offset;
+
+            DSMCCDownloadDataMessage ddm;
+            ddm.header.download_id = download_id;
+            ddm.header.message_id = DSMCC_MSGID_DDB;
+            ddm.module_id = module_id;
+            ddm.module_version = module_version;
+            ddm.block_number = block_number;
+            ddm.block_data.copy(data + block_data_offset, block_data_size);
+
             _carousel.feedDownloadData(ddm);
             break;
         }

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.h
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCExtractor.h
@@ -14,7 +14,7 @@
 #pragma once
 #include "tsDSMCCCarousel.h"
 #include "tsSectionDemux.h"
-#include "tsTableHandlerInterface.h"
+#include "tsSectionHandlerInterface.h"
 #include "tsTSPacket.h"
 #include <filesystem>
 #include <optional>
@@ -32,7 +32,7 @@ namespace ts {
     //!
     //! @ingroup libtsduck mpeg
     //!
-    class TSDUCKDLL DSMCCExtractor : private TableHandlerInterface
+    class TSDUCKDLL DSMCCExtractor : private SectionHandlerInterface
     {
         TS_NOCOPY(DSMCCExtractor);
 
@@ -86,12 +86,12 @@ namespace ts {
         DuckContext&        _duck;
         Options             _options;
         DSMCCCarousel       _carousel;
-        SectionDemux        _demux;
+        SectionDemux        _demux;           //!< Section-level demux (no table assembly, avoids DDB inconsistency noise).
         PID                 _pid = PID_NULL;
         ObjectList          _objects {};
         ObjectByModuleMap   _objects_by_module {};
 
-        virtual void handleTable(SectionDemux&, const BinaryTable&) override;
+        virtual void handleSection(SectionDemux&, const Section&) override;
 
         void onModuleCompleted(uint32_t download_id, uint16_t module_id, const ByteBlock& payload);
 

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCModuleAssembler.cpp
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCModuleAssembler.cpp
@@ -10,6 +10,7 @@
 #include "tsPSIBuffer.h"
 #include "tsDSMCCCompressedModuleDescriptor.h"
 #include "tsDID.h"
+#include "tsMemory.h"
 
 //----------------------------------------------------------------------------
 // Constructor
@@ -128,9 +129,9 @@ void ts::DSMCCModuleAssembler::processDDB(DSMCCDownloadDataMessage& ddm)
     if (it == _modules.end()) {
         // DDB arrived before the DII that declares this module.
         // Buffer it and replay once the DII catches up.
-        _duck.report().verbose(u"Buffering orphan DDB: download_id=0x%X module=0x%X ver=%d (%d bytes)",
-                               ddm.header.download_id, ddm.module_id, ddm.module_version, ddm.block_data.size());
-        _orphan_ddbs[key].push_back({ddm.module_version, std::move(ddm.block_data)});
+        _duck.report().verbose(u"Buffering orphan DDB: download_id=0x%X module=0x%X ver=%d block=%d (%d bytes)",
+                               ddm.header.download_id, ddm.module_id, ddm.module_version, ddm.block_number, ddm.block_data.size());
+        _orphan_ddbs[key].push_back({ddm.module_version, ddm.block_number, std::move(ddm.block_data)});
         return;
     }
 
@@ -141,16 +142,44 @@ void ts::DSMCCModuleAssembler::processDDB(DSMCCDownloadDataMessage& ddm)
         return;
     }
 
-    // Invariant: ddm.block_data already contains the full module payload — the upstream
-    // DSMCC section layer concatenates DDB blocks before handing us the DDM. Do not
-    // reintroduce a per-block bitmap here unless that layer changes.
-    ctx.payload = std::move(ddm.block_data);
+    insertBlock(ctx, ddm.block_number, ddm.block_data);
+}
 
-    ctx.status = ModuleContext::Status::COMPLETE;
 
-    if (_on_module_complete) {
-        _on_module_complete(ctx);
+//----------------------------------------------------------------------------
+// Insert a single block into a module. Returns true if module became complete.
+//----------------------------------------------------------------------------
+
+bool ts::DSMCCModuleAssembler::insertBlock(ModuleContext& ctx, uint16_t block_number, const ByteBlock& data)
+{
+    // Skip duplicate blocks.
+    if (ctx.received_blocks.count(block_number) > 0) {
+        return false;
     }
+
+    // Ensure payload buffer is allocated.
+    if (ctx.payload.size() < ctx.module_size) {
+        ctx.payload.resize(ctx.module_size, 0);
+    }
+
+    // Copy block data to the correct offset within the module payload.
+    const size_t offset = static_cast<size_t>(block_number) * ctx.block_size;
+    const size_t copy_size = std::min(data.size(), static_cast<size_t>(ctx.module_size) - offset);
+    if (offset < ctx.module_size && copy_size > 0) {
+        MemCopy(ctx.payload.data() + offset, data.data(), copy_size);
+        ctx.received_blocks.insert(block_number);
+    }
+
+    // Check if all blocks have been received.
+    if (ctx.received_blocks.size() >= ctx.expected_blocks) {
+        ctx.payload.resize(ctx.module_size);
+        ctx.status = ModuleContext::Status::COMPLETE;
+        if (_on_module_complete) {
+            _on_module_complete(ctx);
+        }
+        return true;
+    }
+    return false;
 }
 
 
@@ -168,18 +197,16 @@ void ts::DSMCCModuleAssembler::replayOrphans(ModuleContext& ctx)
 
     for (auto& orphan : it->second) {
         if (ctx.status == ModuleContext::Status::COMPLETE) {
-            break;  // Already assembled; remaining orphans are redundant duplicates.
+            break;
         }
         if (orphan.module_version != ctx.module_version) {
             continue;
         }
-        _duck.report().verbose(u"Replaying orphan DDB: download_id=0x%X module=0x%X ver=%d (%d bytes)",
-                               ctx.download_id, ctx.module_id, ctx.module_version, orphan.block_data.size());
-        ctx.payload = std::move(orphan.block_data);
-        ctx.status = ModuleContext::Status::COMPLETE;
-        if (_on_module_complete) {
-            _on_module_complete(ctx);
-        }
+
+        _duck.report().verbose(u"Replaying orphan DDB: download_id=0x%X module=0x%X ver=%d block=%d (%d bytes)",
+                               ctx.download_id, ctx.module_id, ctx.module_version, orphan.block_number, orphan.block_data.size());
+
+        insertBlock(ctx, orphan.block_number, orphan.block_data);
     }
     _orphan_ddbs.erase(it);
 }

--- a/src/libtsduck/dtv/dsmcc/tsDSMCCModuleAssembler.h
+++ b/src/libtsduck/dtv/dsmcc/tsDSMCCModuleAssembler.h
@@ -19,6 +19,7 @@
 #include "tsDescriptorList.h"
 #include <functional>
 #include <map>
+#include <set>
 
 namespace ts {
 
@@ -81,6 +82,7 @@ namespace ts {
             bool is_compressed = false;     //!< True if a compressed_module_descriptor is present.
             uint32_t original_size = 0;     //!< Uncompressed size from compressed_module_descriptor.
             ByteBlock payload {};           //!< Complete module payload assembled from DDBs.
+            std::set<uint16_t> received_blocks {}; //!< Set of block_numbers received so far.
             DescriptorList descs {nullptr}; //!< Copy of the DII module's user_info descriptor list. Decoded by consumers on demand.
 
             //!
@@ -168,12 +170,17 @@ namespace ts {
         // the payload to replay once the DII arrives.
         struct OrphanBlock {
             uint8_t   module_version = 0;
+            uint16_t  block_number = 0;
             ByteBlock block_data {};
         };
         std::map<ModuleKey, std::vector<OrphanBlock>> _orphan_ddbs {};
 
         void processDII(const DSMCCUserToNetworkMessage& unm);
         void processDDB(DSMCCDownloadDataMessage& ddm);
+
+        // Insert a single block into a module context.
+        // Returns true if the module became complete as a result.
+        bool insertBlock(ModuleContext& ctx, uint16_t block_number, const ByteBlock& data);
 
         // Apply any buffered DDB whose version matches the freshly registered module.
         void replayOrphans(ModuleContext& ctx);

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.cpp
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.cpp
@@ -55,6 +55,7 @@ void ts::DSMCCDownloadDataMessage::clearContent()
     header.clear();
     module_id = 0;
     module_version = 0;
+    block_number = 0;
     block_data.clear();
 }
 
@@ -113,7 +114,7 @@ void ts::DSMCCDownloadDataMessage::deserializePayload(PSIBuffer& buf, const Sect
     module_version = buf.getUInt8();
 
     buf.skipBytes(1);  // reserved
-    buf.skipBytes(2);  // block_number
+    block_number = buf.getUInt16();
 
     buf.getBytesAppend(block_data);
 }
@@ -133,7 +134,7 @@ void ts::DSMCCDownloadDataMessage::serializePayload(BinaryTable& table, PSIBuffe
 
     buf.pushState();
 
-    uint16_t block_number = 0x0000;
+    uint16_t cur_block_number = 0x0000;
     size_t   block_data_index = 0;
 
     while (block_data_index < block_data.size()) {
@@ -143,14 +144,14 @@ void ts::DSMCCDownloadDataMessage::serializePayload(BinaryTable& table, PSIBuffe
         buf.putUInt8(module_version);
         buf.putUInt8(0xFF);  // reserved
 
-        buf.putUInt16(block_number);
+        buf.putUInt16(cur_block_number);
         block_data_index += buf.putBytes(block_data, block_data_index, std::min(block_data.size() - block_data_index, buf.remainingWriteBytes()));
 
         buf.popState();  // message_length
 
         addOneSection(table, buf);
 
-        block_number++;
+        cur_block_number++;
     }
 }
 

--- a/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
+++ b/src/libtsduck/dtv/tables/mpeg/tsDSMCCDownloadDataMessage.h
@@ -54,6 +54,7 @@ namespace ts {
         DownloadDataHeader header {};           //!< DSM-CC Download Data Header.
         uint16_t           module_id = 0;       //!< Identifies to which module this block belongs.
         uint8_t            module_version = 0;  //!< Identifies the version of the module to which this block belongs.
+        uint16_t           block_number = 0;    //!< Block number within the module (used for multi-block assembly).
         ByteBlock          block_data {};       //!< Conveys the data of the block.
 
         //!

--- a/src/utest/utestDSMCC.cpp
+++ b/src/utest/utestDSMCC.cpp
@@ -31,6 +31,8 @@ class DSMCCTest: public tsunit::Test
     TSUNIT_DECLARE_TEST(Assembler_DiscoverySuppressedOnVersionBump);
     TSUNIT_DECLARE_TEST(Assembler_MultiGroupSameModuleIdDoesNotCollide);
     TSUNIT_DECLARE_TEST(Assembler_SingleGroupBehaviourPreserved);
+    TSUNIT_DECLARE_TEST(Assembler_MultiBlockModuleAssembly);
+    TSUNIT_DECLARE_TEST(Assembler_MultiBlockOutOfOrder);
 
     // --- Carousel ---
     TSUNIT_DECLARE_TEST(Carousel_DataCarouselDSIPopulatesGroups);
@@ -68,7 +70,8 @@ TSUNIT_REGISTER(DSMCCTest);
 namespace {
 
     // Single-module DII (used by assembler tests).
-    ts::DSMCCUserToNetworkMessage makeDII(uint32_t download_id, uint16_t module_id, uint16_t block_size, uint8_t module_version)
+    // When module_size is 0 (default), uses block_size — i.e. a single-block module.
+    ts::DSMCCUserToNetworkMessage makeDII(uint32_t download_id, uint16_t module_id, uint16_t block_size, uint8_t module_version, uint32_t module_size = 0)
     {
         ts::DSMCCUserToNetworkMessage unm;
         unm.header.message_id = ts::DSMCC_MSGID_DII;
@@ -77,7 +80,7 @@ namespace {
         dii.block_size = block_size;
         auto& mod = dii.modules.newEntry();
         mod.module_id = module_id;
-        mod.module_size = block_size;
+        mod.module_size = (module_size > 0) ? module_size : block_size;
         mod.module_version = module_version;
         return unm;
     }
@@ -102,13 +105,14 @@ namespace {
         return unm;
     }
 
-    ts::DSMCCDownloadDataMessage makeDDB(uint32_t download_id, uint16_t module_id, uint8_t module_version, const ts::ByteBlock& payload)
+    ts::DSMCCDownloadDataMessage makeDDB(uint32_t download_id, uint16_t module_id, uint8_t module_version, const ts::ByteBlock& payload, uint16_t block_number = 0)
     {
         ts::DSMCCDownloadDataMessage ddm;
         ddm.header.message_id = ts::DSMCC_MSGID_DDB;
         ddm.header.download_id = download_id;
         ddm.module_id = module_id;
         ddm.module_version = module_version;
+        ddm.block_number = block_number;
         ddm.block_data = payload;
         return ddm;
     }
@@ -253,7 +257,7 @@ TSUNIT_DEFINE_TEST(Assembler_MultiGroupSameModuleIdDoesNotCollide)
     ts::DSMCCModuleAssembler assembler(duck);
 
     std::vector<std::pair<uint32_t, uint16_t>> completed;
-    std::vector<ts::ByteBlock>                 payloads;
+    std::vector<ts::ByteBlock> payloads;
     assembler.setModuleCompletedHandler(
         [&](const ts::DSMCCModuleAssembler::ModuleContext& ctx) {
             completed.emplace_back(ctx.download_id, ctx.module_id);
@@ -300,18 +304,109 @@ TSUNIT_DEFINE_TEST(Assembler_SingleGroupBehaviourPreserved)
             ++count;
         });
 
-    const uint32_t dlid = 0x1234;
+    const uint32_t download_id = 0x1234;
     const uint16_t block_size = 8;
     const ts::ByteBlock pad(block_size, 0x00);
 
-    for (uint16_t m = 1; m <= 3; ++m) {
-        auto dii = makeDII(dlid, m, block_size, 0);
+    for (uint16_t mod = 1; mod <= 3; ++mod) {
+        auto dii = makeDII(download_id, mod, block_size, 0);
         assembler.feedUserToNetwork(dii);
-        auto ddb = makeDDB(dlid, m, 0, pad);
+        auto ddb = makeDDB(download_id, mod, 0, pad);
         assembler.feedDownloadData(ddb);
     }
 
     TSUNIT_EQUAL(3u, count);
+}
+
+
+// When a module is larger than a single block, the assembler must stitch
+// multiple DDB sections together at the correct offsets. This is the common
+// case for real-world carousels (e.g. a 350-byte module with 100-byte blocks
+// needs 4 DDB sections: 100 + 100 + 100 + 50).
+TSUNIT_DEFINE_TEST(Assembler_MultiBlockModuleAssembly)
+{
+    ts::DuckContext duck;
+    ts::DSMCCModuleAssembler assembler(duck);
+
+    ts::ByteBlock completed_payload;
+    assembler.setModuleCompletedHandler(
+        [&](const ts::DSMCCModuleAssembler::ModuleContext& ctx) {
+            completed_payload = ctx.payload;
+        });
+
+    const uint32_t download_id = 0x0000002A;
+    const uint16_t module_id = 0x0002;
+    const uint16_t block_size = 100;
+    const uint32_t module_size = 350;  // 4 blocks: 100 + 100 + 100 + 50
+
+    // Announce the module via DII with explicit multi-block geometry.
+    auto dii = makeDII(download_id, module_id, block_size, 1, module_size);
+    assembler.feedUserToNetwork(dii);
+
+    // Feed all 4 blocks sequentially. Each block is filled with a distinct
+    // byte so we can verify placement after assembly.
+    for (uint16_t block = 0; block < 4; ++block) {
+        const size_t this_block_size = (block < 3) ? block_size : (module_size - 3 * block_size);
+        const ts::ByteBlock data(this_block_size, static_cast<uint8_t>(block + 1));
+        auto ddb = makeDDB(download_id, module_id, 1, data, block);
+        assembler.feedDownloadData(ddb);
+    }
+
+    // The module should now be fully assembled.
+    TSUNIT_EQUAL(module_size, completed_payload.size());
+
+    // Spot-check that each block landed at the right offset.
+    TSUNIT_EQUAL(1u, completed_payload[0]);    // first byte of block 0
+    TSUNIT_EQUAL(1u, completed_payload[99]);   // last byte of block 0
+    TSUNIT_EQUAL(2u, completed_payload[100]);  // first byte of block 1
+    TSUNIT_EQUAL(3u, completed_payload[200]);  // first byte of block 2
+    TSUNIT_EQUAL(4u, completed_payload[300]);  // first byte of block 3 (final, 50 bytes)
+    TSUNIT_EQUAL(4u, completed_payload[349]);  // last byte of the module
+}
+
+
+// In broadcast streams, DDB sections often arrive out of order due to
+// interleaving across PIDs or simply because the muxer doesn't guarantee
+// sequential delivery. The assembler must handle blocks arriving in any
+// sequence and only fire completion once every block is in place.
+TSUNIT_DEFINE_TEST(Assembler_MultiBlockOutOfOrder)
+{
+    ts::DuckContext duck;
+    ts::DSMCCModuleAssembler assembler(duck);
+
+    ts::ByteBlock completed_payload;
+    assembler.setModuleCompletedHandler(
+        [&](const ts::DSMCCModuleAssembler::ModuleContext& ctx) {
+            completed_payload = ctx.payload;
+        });
+
+    const uint32_t download_id = 0x0000002A;
+    const uint16_t module_id = 0x0005;
+    const uint16_t block_size = 64;
+    const uint32_t module_size = 192;  // exactly 3 blocks of 64 bytes
+
+    auto dii = makeDII(download_id, module_id, block_size, 0, module_size);
+    assembler.feedUserToNetwork(dii);
+
+    // Helper: send a single block filled with a recognizable byte pattern.
+    auto feedBlock = [&](uint16_t block) {
+        const ts::ByteBlock data(block_size, static_cast<uint8_t>(block + 0x10));
+        auto ddb = makeDDB(download_id, module_id, 0, data, block);
+        assembler.feedDownloadData(ddb);
+    };
+
+    // Deliver blocks in reverse order: 2, 0, 1.
+    feedBlock(2);  // only 1 of 3 — should not complete
+    TSUNIT_ASSERT(completed_payload.empty());
+    feedBlock(0);  // 2 of 3 — still waiting for block 1
+    TSUNIT_ASSERT(completed_payload.empty());
+    feedBlock(1);  // all 3 received — module should now be complete
+
+    TSUNIT_EQUAL(module_size, completed_payload.size());
+    // Each block's fill byte lets us verify correct placement.
+    TSUNIT_EQUAL(0x10u, completed_payload[0]);    // block 0 data
+    TSUNIT_EQUAL(0x11u, completed_payload[64]);   // block 1 data
+    TSUNIT_EQUAL(0x12u, completed_payload[128]);  // block 2 data
 }
 
 


### PR DESCRIPTION
<!--
Please read the TSDuck contribution guidelines for pull requests:
https://tsduck.io/docs/tsduck-dev.html#chap-contribution
-->

#### Related issue (if any):
#1719 

#### Affected components:
`dsmcc`

#### Brief description of the proposed changes:
Modules requiring more than 256 DDB sections were silently truncated because `section_number` wraps at 255. The section demux rejected these as inconsistent, and the assembler used `section_number` as the block index.

Now using `block_number` from the DDB payload for assembly, switched the extractor to section-level handling to bypass table consistency checks, and added a flag to prevent repeated DSI bootstrap processing.
