### PR TITLE
Nolnbcontrol

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,7 +7,12 @@ VERSION 3.45-4693 (May 2026)
 [IMP] Improvements on existing commands and plugins:
 
   * New options in existing commands and plugins:
-    - Option --no-lnb-control added in input plugin "dektec".
+    - Option --no-lnb-control in plugin "dektec" (input) to explicitly disable
+      LNB control on DVB-S/S2 receivers.
+
+  * Plugin "dektec" (input): on DVB-S/S2 receivers, LNB control is now
+    automatically skipped on input channels which do not support it instead of 
+    failing.
 
 -------------------------------------------------------------------------------
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,15 @@ TSDUCK CHANGE LOG AND RELEASE NOTES
 
 -------------------------------------------------------------------------------
 
+VERSION 3.45-4693 (May 2026)
+
+[IMP] Improvements on existing commands and plugins:
+
+  * New options in existing commands and plugins:
+    - Option --no-lnb-control added in input plugin "dektec".
+
+-------------------------------------------------------------------------------
+
 VERSION 3.45-4684 (May 2026)
 
 [IMP] Improvements on existing commands and plugins:

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -14,6 +14,7 @@ Eric De Jong
 William del Strother
 Lola Delannoy
 Joey Ekstrom
+Baptiste Fave
 Gareth Fenn
 Martin Frétigné
 Thomas Göttgens

--- a/doc/user/plugins/dektec-input.adoc
+++ b/doc/user/plugins/dektec-input.adoc
@@ -228,11 +228,12 @@ Must be one of `ATSC-VSB`, `DAB`, `DVB-C2`, `DVB-S`, `DVB-S-QPSK` (same as `DVB-
 *--no-lnb-control*
 
 [.optdoc]
-DVB-S/S2 receivers: do not send any control command to the LNB
+DVB-S/S2 receivers: do not send any control command to the LNB.
 The intermediate frequency is still computed from `--satellite-frequency` and `--lnb` if specified.
 
 [.optdoc]
-This is useful on receivers that do not support LNB control
+This is useful to explicitly disable LNB control in a lab where sending those signals on the cable is a problem.
+Note: even without this option, LNB control is automatically skipped on input channels which do not support it.
 
 [.opt]
 *--polarity* _value_

--- a/doc/user/plugins/dektec-input.adoc
+++ b/doc/user/plugins/dektec-input.adoc
@@ -225,6 +225,16 @@ Must be one of `ATSC-VSB`, `DAB`, `DVB-C2`, `DVB-S`, `DVB-S-QPSK` (same as `DVB-
 `ISDB-T`, `QAM` (auto-detection of QAM type), `16-QAM`, `32-QAM`, `64-QAM`, `128-QAM`, `256-QAM`.
 
 [.opt]
+*--no-lnb-control*
+
+[.optdoc]
+DVB-S/S2 receivers: do not send any control command to the LNB
+The intermediate frequency is still computed from `--satellite-frequency` and `--lnb` if specified.
+
+[.optdoc]
+This is useful on receivers that do not support LNB control
+
+[.opt]
 *--polarity* _value_
 
 [.optdoc]

--- a/src/libtsdektec/plugins/tsDektecInputPlugin.cpp
+++ b/src/libtsdektec/plugins/tsDektecInputPlugin.cpp
@@ -247,6 +247,10 @@ ts::DektecInputPlugin::DektecInputPlugin(TSP* tsp_) :
          u"The supported modulation types depend on the device model. "
          u"The default modulation type is DVB-S.\n");
 
+    option(u"no-lnb-control");
+    help(u"no-lnb-control",
+         u"DVB-S/S2 receivers: do not send any control command to the LNB");
+
     option(u"polarity", 0, PolarizationEnum());
     help(u"polarity",
          u"DVB-S/S2 receivers: indicate the polarity. The default is \"vertical\".");
@@ -505,6 +509,11 @@ bool ts::DektecInputPlugin::getOptions()
             tsp->error(u"invalid Dektec demodulation parameters: %s", DektecStrError(status));
             success = false;
         }
+    }
+
+    // Skip LNB setup if no-lnb-control option is present
+    if (present(u"no-lnb-control")) {
+        _guts->lnb_setup = false;
     }
 
     return success;

--- a/src/libtsdektec/plugins/tsDektecInputPlugin.cpp
+++ b/src/libtsdektec/plugins/tsDektecInputPlugin.cpp
@@ -646,9 +646,14 @@ bool ts::DektecInputPlugin::start()
     // Apply demodulation settings
     if (_guts->demod_freq > 0) {
 
-        // Configure the LNB for satellite reception.
-        if (_guts->lnb_setup && !configureLNB()) {
-            return false;
+        // Configure the LNB for satellite reception, only if input channel supports it
+        if (_guts->lnb_setup) {
+            if ((dt_flags & DTAPI_CAP_LNB) == 0) {
+                tsp->verbose(u"input channel does not support LNB control, skipping it");
+            }
+            else if (!configureLNB()) {
+                return false;
+            }
         }
 
         // Tune to the frequency and demodulation parameters.


### PR DESCRIPTION
#### Affected components:
tsp -I dektec

#### Brief description of the proposed changes:
Some Dektec input channels don't support LNB control (like odd channels of the DTA-2128) and will have this error:
```
* dektec: using Dektec device 0, input channel 1 (DTA-2128 port 2)
* Error: dektec: error enabling Dektec LNB controller: DTAPI_E_NOT_SUPPORTED (DTAPI status 4119)
```
Whereas input channel 0 is working fine because it supports LNB control

```
tsdektec -av
DTAPI: 6.13.0.242, DtPcie: 3.6.4.398, DtPcieNw: -1.-1.-1.-1, Service: 5.2.8.141

* Device 0: DTA-2128 (Octal DVB-S2X Receiver)
  Physical ports: 8
  Channels: input: 8, output: 0
  Input 0: DTA-2128 port 1 (top), Demodulator (**LNB**, Automatic spectral inversion
      correction., Automatic symbol rate detection., Manual symbol rate., L-band
      950-2150MHz, Uni-directional input, Transparent mode, MPEG-2 transport
      stream, Demodulation, Adjustable roll-off factor, DVB-S reception, DVB-S2
      reception, DVB-S2 multiple input stream reception)
  Input 1: DTA-2128 port 2, Demodulator (Automatic spectral inversion
      correction., Automatic symbol rate detection., Manual symbol rate., L-band
      950-2150MHz, Uni-directional input, Transparent mode, MPEG-2 transport
      stream, Demodulation, Adjustable roll-off factor, DVB-S reception, DVB-S2
      reception, DVB-S2 multiple input stream reception)
   Input 2: [...]
```

It seems that dektec input plugin will always try to control the LNB when DVB-S or DVB-S2 modulations are selected.
The idea is to add an option to allow to disable LNB control when it's not needed