### PR TITLE
Fixed LNB control enabling skipped instead of being disabled

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,8 @@ VERSION 3.45-4695 (June 2026)
   * Plugin  "dektec"  (input):  on  DVB-S/S2  receivers,  LNB  control  is  now
     automatically  skipped on input channels which do not support it instead of
     failing.
+  * Plugin "dektec" (input): If channel has LNB capability but should not be
+    enabled, we force LNB disabling instead of skipping LNB enabling
   * New options in existing commands and plugins:
     - Options  --preserve-units,  --silent-after, --stuffing in plugins "slice"
       and "time".

--- a/src/libtsdektec/plugins/tsDektecInputPlugin.cpp
+++ b/src/libtsdektec/plugins/tsDektecInputPlugin.cpp
@@ -655,6 +655,14 @@ bool ts::DektecInputPlugin::start()
                 return false;
             }
         }
+        else if ((dt_flags & DTAPI_CAP_LNB) != 0) {
+            // If channel has LNB capability but lnb_setup is false, we force LNB disabling
+            debug(u"disabling LNB control");
+            status = _guts->chan.LnbEnable(false);
+            if (status != DTAPI_OK) {
+                return startError(u"error disabling LNB control", status);
+            }
+        }
 
         // Tune to the frequency and demodulation parameters.
         debug(u"tuning to frequency %'d Hz, demod: %s", _guts->demod_freq, demodParsToXml());


### PR DESCRIPTION
#### Affected components:
tsp -I dektec

#### Brief description of the proposed changes:
The LNB output voltage is actually not reset when launching tsp. So if LNB was previously enabled, even if tsp is launched with --no-lnb-control option, we will still measure 13V on the port, because we don't actually disable LNB, we skip the enabling. So the promise made in the docs : "This is useful to explicitly disable LNB control" is not kept

The proposed fix is that if channel has LNB capability but should not be enabled, we force LNB disabling instead of skipping LNB enabling

```
tsp -v -v --debug -I dektec --device 0 --channel 4 --no-lnb-control --modulation DVB-S2 --frequency 1759500000 --symbol-rate 24000000 -O drop
tsp: Debug: ====> tsp -v -v --debug
* Debug: libtsdektec loaded
* Debug: registering feature "dektec"
* Debug: registering bitrate calculator 0x0000747362B2DF90 for 0 systems (none)
* Debug: registering input plugin "dektec", status: ok
* Debug: registering output plugin "dektec", status: ok
* Debug: dektec: ====> tsp -I dektec --device 0 --channel 4 --no-lnb-control --modulation DVB-S2 --frequency 1759500000 --symbol-rate 24000000
* Debug: drop: ====> tsp -O drop
* Debug: dektec: Dektec demodulation parameters: <DtDemodPars mod="32">
<S2 cr="15" plt="3" inv="48" fec="12" symb="24000000" am="0" hm="5">
<Mcs/>
</S2>
</DtDemodPars>
* Debug: tsp: buffer size: 89,240 TS packets, 16,777,120 bytes
* dektec: using Dektec device 0, input channel 4 (DTA-2128 port 5)
* Debug: dektec: attaching to device DTA-2128 serial 0x00000000XXXXXXXX
* Debug: dektec: attaching to port 5
* Debug: dektec: resetting channel, mode: 1
* Debug: dektec: setting RxControl, mode: 0
* Debug: dektec: clearing FIFO and flags
* Debug: dektec: getting FIFO max size
* Debug: dektec: max FIFO size: 8,388,608 bytes
* Debug: dektec: using FIFO size: 8,388,608 bytes
* Debug: dektec: disabling LNB control
* Debug: dektec: tuning to frequency 1,759,500,000 Hz, demod: <DtDemodPars mod="32">
```