### PR TITLE
tsp: add DOT processing-chain output

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ VERSION 3.45-4727 (July 2026)
       and "time".
     - Option --no-lnb-control in input plugin "dektec".
     - Option --control-ephemeral-rsa-bits in command "tsp".
+    - Option --dot in command "tsp".
     - Option --remote-ephemeral-rsa-bits in command "tsswitch".
     - Option --snddropdelay in input and output plugins "srt".
     - Options --super-cas-id and --client-limit in "tsecmg".

--- a/doc/user/commands/tsp.adoc
+++ b/doc/user/commands/tsp.adoc
@@ -386,6 +386,14 @@ See also the options `--max-input-packets` and `--max-flushed-packets`
 to adjust the latency without modifying the global buffer size.
 
 [.opt]
+*--dot*
+
+[.optdoc]
+Output the top-level plugin chain in Graphviz DOT format and exit without processing transport stream packets.
+The graph contains the input plugin, the ordered packet processing plugins, and the output plugin.
+Plugin options are not included.
+
+[.opt]
 *--final-wait* _milliseconds_
 
 [.optdoc]

--- a/src/tstools/tsp.cpp
+++ b/src/tstools/tsp.cpp
@@ -34,6 +34,7 @@ namespace {
         TSPOptions(int argc, char *argv[]);
 
         // Option values
+        bool                dot = false;         // Output the plugin chain in Graphviz DOT format.
         bool                monitor = false;     // Run a resource monitoring thread in the background.
         ts::UString         monitor_config {};   // System monitoring configuration file.S
         ts::DuckContext     duck {this};         // TSDuck context
@@ -55,6 +56,11 @@ TSPOptions::TSPOptions(int argc, char *argv[]) :
     log_args.defineArgs(*this);
     tsp_args.defineArgs(*this);
 
+    option(u"dot");
+    help(u"dot",
+         u"Output the top-level plugin chain in Graphviz DOT format and exit. "
+         u"Plugin options are not included.");
+
     option(u"monitor", 'm', STRING, 0, 1, 0, UNLIMITED_VALUE, true);
     help(u"monitor", u"filename",
          u"Continuously monitor the system resources which are used by tsp. "
@@ -66,6 +72,7 @@ TSPOptions::TSPOptions(int argc, char *argv[]) :
     analyze(argc, argv);
 
     // Load option values.
+    dot = present(u"dot");
     monitor = present(u"monitor");
     getValue(monitor_config, u"monitor");
     duck.loadArgs(*this);
@@ -74,6 +81,34 @@ TSPOptions::TSPOptions(int argc, char *argv[]) :
 
     // Final checking
     exitOnError();
+}
+
+
+//----------------------------------------------------------------------------
+//  Output the top-level plugin chain in Graphviz DOT format.
+//----------------------------------------------------------------------------
+
+namespace {
+    void OutputGraph(const ts::TSProcessorArgs& args)
+    {
+        std::cout << "digraph tsp {" << std::endl
+                  << "    rankdir = LR;" << std::endl
+                  << "    node [shape = box];" << std::endl
+                  << "    input [label = \"Input\\n" << args.input.name.toJSON() << "\"];" << std::endl;
+
+        ts::UString previous(u"input");
+        for (size_t index = 0; index < args.plugins.size(); ++index) {
+            const ts::UString current(ts::UString::Format(u"processor_%d", index));
+            std::cout << "    " << current << " [label = \"Processor " << index << "\\n"
+                      << args.plugins[index].name.toJSON() << "\"];" << std::endl
+                      << "    " << previous << " -> " << current << ";" << std::endl;
+            previous = current;
+        }
+
+        std::cout << "    output [label = \"Output\\n" << args.output.name.toJSON() << "\"];" << std::endl
+                  << "    " << previous << " -> output;" << std::endl
+                  << "}" << std::endl;
+    }
 }
 
 
@@ -122,6 +157,12 @@ int MainCode(int argc, char *argv[])
     // Get command line options.
     TSPOptions opt(argc, argv);
     CERR.setMaxSeverity(opt.maxSeverity());
+
+    // Describing the chain does not load plugins or process transport streams.
+    if (opt.dot) {
+        OutputGraph(opt.tsp_args);
+        return EXIT_SUCCESS;
+    }
 
     // Prevent from being killed when writing on broken pipes.
     ts::IgnorePipeSignal();


### PR DESCRIPTION
## Summary

Add a `--dot` option to `tsp` which prints a deterministic Graphviz DOT representation of the top-level processing chain and exits without processing a transport stream.

The graph contains:

- one input node;
- processing-plugin nodes in command-line order;
- one output node;
- unambiguous node identifiers when plugin types are repeated.

The user documentation and changelog are updated accordingly.

## Scope

The graph identifies plugin types but does not include plugin parameters or argument values.

This change does not:

- expand nested merge or fork pipelines;
- render graphics;
- open or process the transport-stream input;
- create the configured transport-stream output.

## Verification

- Built successfully with Clang 22.1.8.
- Shared unit tests: 750 tests and 34,095 assertions passed.
- Static unit tests: 747 tests and 34,072 assertions passed.
- Verified zero, one, multiple, and repeated processing-plugin cases.
- Verified deterministic output and Graphviz parser acceptance.
- Verified that input/output paths and plugin argument values are absent from the DOT output.
- Verified that DOT generation does not open the input or create the output.

This implements the top-level processing-chain DOT output requested in #960.