### PR TITLE
Fix build with OpenSSL 4.0

### DIFF
--- a/src/libtscore/tls/unix/tsOpenSSL.h
+++ b/src/libtscore/tls/unix/tsOpenSSL.h
@@ -44,6 +44,11 @@
         // emulates OpenSSL v3, except that OPENSSL_atexit is not available.
         #define OPENSSL_atexit atexit
     #endif
+    #if OPENSSL_VERSION_MAJOR >= 4
+        // OpenSSL v4 removed OPENSSL_atexit().
+        #include <cstdlib>
+        #define OPENSSL_atexit atexit
+    #endif
     #include "tsAfterStandardHeaders.h"
 
 #else

--- a/src/libtscore/tls/unix/tsTLSCertificateGuts.cpp
+++ b/src/libtscore/tls/unix/tsTLSCertificateGuts.cpp
@@ -220,13 +220,20 @@ bool ts::TLSCertificate::createEphemeralCertificate(size_t rsa_bits)
         }
 
         // Set subject name (CN) and issuer to host name (this is a self-signed certificate).
-        X509_NAME* subject_name = X509_get_subject_name(x509); // internal pointer inside x509
-        if (!X509_NAME_add_entry_by_txt(subject_name, "CN", MBSTRING_ASC, reinterpret_cast<const unsigned char*>(Subject().toUTF8().c_str()), -1, -1, 0)) {
-            report().error(u"error setting subject of certificate");
+        // X509_get_subject_name() returns a const pointer since OpenSSL 4.0, so the
+        // name is built separately and handed to the certificate, which copies it.
+        X509_NAME* const subject_name = X509_NAME_new();
+        if (subject_name == nullptr) {
+            report().error(u"error allocating subject of certificate");
             break;
         }
-        if (!X509_set_issuer_name(x509, subject_name)) {
-            report().error(u"error setting issuer of certificate");
+        const bool subject_ok =
+            X509_NAME_add_entry_by_txt(subject_name, "CN", MBSTRING_ASC, reinterpret_cast<const unsigned char*>(Subject().toUTF8().c_str()), -1, -1, 0) &&
+            X509_set_subject_name(x509, subject_name) &&
+            X509_set_issuer_name(x509, subject_name);
+        X509_NAME_free(subject_name);
+        if (!subject_ok) {
+            report().error(u"error setting subject of certificate");
             break;
         }
 

--- a/src/libtscore/tls/unix/tsTLSContextGuts.cpp
+++ b/src/libtscore/tls/unix/tsTLSContextGuts.cpp
@@ -310,15 +310,18 @@ bool ts::TLSContext::initClient(const TLSConnectionBase& params)
         // Set DNS names for verification of the server's certificate.
         bool names_ok = true;
         if (params.verifyPeer() && !params.serverName().empty()) {
+            // SSL_set1_host() and SSL_add1_host() are deprecated since OpenSSL 4.0.
+            // They were wrappers around these calls on the verification parameters.
+            X509_VERIFY_PARAM* const vparam = SSL_get0_param(_guts->ssl);
             // Set main server name.
-            if (!SSL_set1_host(_guts->ssl, params.serverName().toUTF8().c_str())) {
-                report().error(u"error setting TLS server name (SSL_set1_host)");
+            if (!X509_VERIFY_PARAM_set1_host(vparam, params.serverName().toUTF8().c_str(), 0)) {
+                report().error(u"error setting TLS server name (X509_VERIFY_PARAM_set1_host)");
                 break; // do {} while
             }
             // Set additional names.
             for (const auto& name : params.additionalServerNames()) {
-                if (!name.empty() && !SSL_add1_host(_guts->ssl, name.toUTF8().c_str())) {
-                    report().error(u"error setting TLS server name (SSL_set1_host)");
+                if (!name.empty() && !X509_VERIFY_PARAM_add1_host(vparam, name.toUTF8().c_str(), 0)) {
+                    report().error(u"error setting TLS server name (X509_VERIFY_PARAM_add1_host)");
                     names_ok = false;
                     break; // inner for() {} => need names_ok to exit outer do {} while
                 }


### PR DESCRIPTION
#### Related issue (if any):
None.

#### Affected components:
TLS support of `libtscore` on Unix: `tsOpenSSL.h`, `tsTLSContextGuts.cpp`, `tsTLSCertificateGuts.cpp`.

#### Brief description of the proposed changes:
Building TSDuck against OpenSSL 4.0 currently fails. Three incompatibilities:

1. `OPENSSL_atexit()` no longer exists. `tsOpenSSL.h` already maps it to `atexit()`, but only in the branch for versions below 3, which was added for LibreSSL and which OpenSSL 4 never reaches. Version 4 gets its own branch.

2. `SSL_set1_host()` and `SSL_add1_host()` are deprecated. The names to verify are now set through `X509_VERIFY_PARAM_set1_host()` and `X509_VERIFY_PARAM_add1_host()` on the verification parameters of the connection, which is what the SSL-level wrappers called internally.

3. `X509_get_subject_name()` returns a const pointer, so the subject name of a certificate can no longer be filled in place. It is built with `X509_NAME_new()` and passed to `X509_set_subject_name()`, which copies it.

Two points for your consideration:

For the second item, OpenSSL 4.0 recommends the new `SSL_set1_dnsname()` and `SSL_set1_ipaddr()` instead. Those exist only from 4.0 on, so using them needs a version switch, and `SSL_set1_dnsname()` validates the DNS name structure, which would reject a server name given as a literal IP address. Going through the verification parameters avoids both, needs no version switch and cannot change behaviour, since it is the same code path the wrappers used.

The certificate change merges two error messages into one, because the three calls are now a single `&&` expression with a `X509_NAME_free()` after it. Keeping them apart would need a free on every error path.